### PR TITLE
clean up README

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,1 @@
 Support for serialising Haskell to and from Yaml.
-
-This is a low level library. Unless you know what you are doing, 
-you probably want to use data-objects-yaml instead:
-
-  http://github.com/snoyberg/data-object-yaml


### PR DESCRIPTION
On Hackage, the data-object-yaml package says "This package is obsolete: use yaml instead."
