### PR TITLE
libyaml Makefile

### DIFF
--- a/libyaml/Makefile
+++ b/libyaml/Makefile
@@ -1,0 +1,9 @@
+CC = gcc
+CFLAGS = -shared
+OBJECTS = api.o dumper.o emitter.o loader.o parser.o reader.o scanner.o writer.o
+LIB = libyaml.so
+LFLAGS = -shared -Wl,-soname,libyaml.so
+%.o: %.c
+	$(CC) $(CFLAGS) -c -fPIC $<
+yaml: $(OBJECTS)
+	$(CC) $(LFLAGS) -o $(LIB) $(OBJECTS)


### PR DESCRIPTION
It is now possible to load up Text/Libyaml.hs into GHCi. First, run
`make yaml` under libyaml/, then do

```
ghci Text/Libyaml.hs -L./libyaml -lyaml -L. -lhelper
```

. The libhelper.so file necessary for this command is already taken care
of with the Makefile that lives in the project's root directory.
