### PR TITLE
Fix YAML_DECLARE macro for MINGW32 architecture.

### DIFF
--- a/libyaml/yaml.h
+++ b/libyaml/yaml.h
@@ -26,7 +26,9 @@ extern "C" {
 
 /** The public API declaration. */
 
-#ifdef _WIN32
+#if defined(__MINGW32__)
+#   define  YAML_DECLARE(type)  type
+#elif defined(_WIN32)
 #   if defined(YAML_DECLARE_STATIC)
 #       define  YAML_DECLARE(type)  type
 #   elif defined(YAML_DECLARE_EXPORT)


### PR DESCRIPTION
MinGW declares `_WIN32`. Since `YAML_DECLARE_STATIC` isn't declared
before yaml.h is included, `YAML_DECLARE` will expand to

```
__declspec(dllexport) type
```

which doesn't work with MinGW, instead you would end up with undefined references to `_impl__yaml_*`. Checking whether you're currently in a MINGW32 setting fixes that behaviour.

This behaviour was introduces by the libyaml update, which removed `define YAML_DECLARE_STATIC` (#583abc2f77fa9fb4dfb3c0e38faac08181851c42).
