### PR TITLE
Patch for Win64 "strdup symbol not found" link problem.

### DIFF
--- a/libyaml/api.c
+++ b/libyaml/api.c
@@ -5,6 +5,9 @@
  * Get the library version.
  */
 
+/*
+ * added to support _WIN64
+ */
 #if _WIN64
 #define STRDUP _strdup
 #else


### PR DESCRIPTION
Patch only tested on Win64 (mingw-64)
