### PR TITLE
Enable unicode output by default.

### DIFF
--- a/Text/Libyaml.hs
+++ b/Text/Libyaml.hs
@@ -310,6 +310,11 @@ foreign import ccall unsafe "get_buffer_used"
 foreign import ccall unsafe "my_emitter_set_output"
     c_my_emitter_set_output :: Emitter -> Buffer -> IO ()
 
+#ifndef __NO_UNICODE__
+foreign import ccall unsafe "yaml_emitter_set_unicode"
+    c_yaml_emitter_set_unicode :: Emitter -> CInt -> IO ()
+#endif
+
 foreign import ccall unsafe "yaml_emitter_set_output_file"
     c_yaml_emitter_set_output_file :: Emitter -> File -> IO ()
 
@@ -618,6 +623,9 @@ runEmitter allocI closeI =
         emitter <- mallocBytes emitterSize
         res <- c_yaml_emitter_initialize emitter
         when (res == 0) $ throwIO $ YamlException "c_yaml_emitter_initialize failed"
+#ifndef __NO_UNICODE__
+        c_yaml_emitter_set_unicode emitter 1
+#endif
         a <- allocI emitter
         return (emitter, a)
     cleanup (emitter, _) = do

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -37,6 +37,10 @@ flag system-libyaml
   description: Use the system-wide libyaml instead of the bundled copy
   default: False
 
+flag no-unicode
+  description: Don't enable unicode output. Instead, unicode characters will be escaped.
+  default: False
+
 library
     build-depends:   base >= 4 && < 5
                    , transformers >= 0.1
@@ -58,6 +62,8 @@ library
     ghc-options:     -Wall
     c-sources:       c/helper.c
     include-dirs:    c
+    if flag(no-unicode)
+            cpp-options:     -D__NO_UNICODE__
     if flag(system-libyaml)
             pkgconfig-depends: yaml-0.1
     else


### PR DESCRIPTION
This should fix issue #32. The output encoding is still set at YAML_ANY_ENCODING, allowing libyaml to pick whatever it deems most appropriate on the system.
