### PR TITLE
Include.hs needs conduit 1.1+ to build

### DIFF
--- a/yaml.cabal
+++ b/yaml.cabal
@@ -41,7 +41,7 @@ library
     build-depends:   base >= 4 && < 5
                    , transformers >= 0.1
                    , bytestring >= 0.9.1.4
-                   , conduit >= 1.0.11 && < 1.3
+                   , conduit >= 1.1.0 && < 1.3
                    , resourcet >= 0.3 && < 1.2
                    , aeson >= 0.5
                    , containers


### PR DESCRIPTION
yaml-0.8.10 needs conduit-1.1 to build:

Data/Yaml/Include.hs:35:21:
    Couldn't match type ‘()’ with ‘Event’
    Expected type: ConduitM Event Event m1 ()
      Actual type: Source m1 Event
    In a stmt of a 'do' block:
      go (cfp : seen) includeFile
      $= CL.filter (`notElem` irrelevantEvents)
    In the expression:
      do { let includeFile = takeDirectory cfp </> unpack (decodeUtf8 f);
           go (cfp : seen) includeFile
           $= CL.filter (`notElem` irrelevantEvents) }
    In a case alternative:
        EventScalar f (UriTag "!include") _ _
          -> do { let includeFile = ...;
                  go (cfp : seen) includeFile
                  $= CL.filter (`notElem` irrelevantEvents) }
