### PR TITLE
Function to print prettier parse exceptions

### DIFF
--- a/Data/Yaml.hs
+++ b/Data/Yaml.hs
@@ -24,6 +24,7 @@ module Data.Yaml
     , Object
     , Array
     , ParseException(..)
+    , prettyPrintParseException
     , YamlException (..)
     , YamlMark (..)
       -- * Constructors and accessors

--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -71,15 +71,6 @@ instance Exception ParseException where
 --
 prettyPrintParseException :: ParseException -> String
 prettyPrintParseException NonScalarKey = "Non scalar key"
-prettyPrintParseException (InvalidYaml mye) =
-  case mye of
-    Just ye -> "Invalid yaml: " ++ show ye
-    _ -> "Invalid yaml"
-prettyPrintParseException (AesonException e) =
-  "Aeson exception: " ++ e
-prettyPrintParseException CyclicIncludes = "Cyclic includes"
-prettyPrintParseException (OtherParseException e) =
-  "Parse exception: " ++ show e
 prettyPrintParseException (UnknownAlias n) =
   "Unknown alias: " ++ n
 prettyPrintParseException (UnexpectedEvent r e) = unlines
@@ -87,11 +78,20 @@ prettyPrintParseException (UnexpectedEvent r e) = unlines
   , "  Received: " ++ maybe "None" show r
   , "  Expected: " ++ maybe "None" show e
     ]
+prettyPrintParseException (InvalidYaml mye) =
+  case mye of
+    Just ye -> "Invalid yaml: " ++ show ye
+    _ -> "Invalid yaml"
+prettyPrintParseException (AesonException e) =
+  "Aeson exception: " ++ e
+prettyPrintParseException (OtherParseException e) =
+  "Parse exception: " ++ show e
 prettyPrintParseException (NonStringKeyAlias n v) = unlines
   [ "Non-string key alias:"
   , "  Anchor name: " ++ n
   , "  Value: " ++ show v 
     ]
+prettyPrintParseException CyclicIncludes = "Cyclic includes"
 
 newtype PErrorT m a = PErrorT { runPErrorT :: m (Either ParseException a) }
 instance Monad m => Functor (PErrorT m) where

--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -54,6 +54,28 @@ data ParseException = NonScalarKey
     deriving (Show, Typeable)
 instance Exception ParseException
 
+-- | Alternative to 'show' to display a 'ParseException' on the screen.
+--   Instead of displaying the data constructors applied to their arguments,
+--   a more textual output is returned. For example, instead of printing:
+--
+-- > AesonException "The key \"foo\" was not found"
+--
+--   It looks more pleasant to print:
+--
+-- > Aeson exception: The key "foo" was not found
+--
+prettyPrintParseException :: ParseException -> String
+prettyPrintParseException NonScalarKey = "Non scalar key"
+prettyPrintParseException InvalidYaml mye =
+  case mye of
+    Just ye -> "Invalid yaml: " ++ show ye
+    _ -> "Invalid yaml"
+prettyPrintParseException (AesonException e) =
+  "Aeson exception: " ++ e
+prettyPrintParseException pe = show pe
+-- TODO: This is just a stab at the implementation.
+--       If the idea is likely to be merged, I can develop it further.
+
 newtype PErrorT m a = PErrorT { runPErrorT :: m (Either ParseException a) }
 instance Monad m => Functor (PErrorT m) where
     fmap = liftM

--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -91,7 +91,7 @@ prettyPrintParseException (NonStringKeyAlias n v) = unlines
   [ "Non-string key alias:"
   , "  Anchor name: " ++ n
   , "  Value: " ++ show v 
-prettyPrintParseException pe = show pe
+    ]
 
 newtype PErrorT m a = PErrorT { runPErrorT :: m (Either ParseException a) }
 instance Monad m => Functor (PErrorT m) where

--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -80,6 +80,17 @@ prettyPrintParseException (AesonException e) =
 prettyPrintParseException CyclicIncludes = "Cyclic includes"
 prettyPrintParseException (OtherParseException e) =
   "Parse exception: " ++ show e
+prettyPrintParseException (UnknownAlias n) =
+  "Unknown alias: " ++ n
+prettyPrintParseException (UnexpectedEvent r e) = unlines
+  [ "Unexpected event:"
+  , "  Received: " ++ maybe "None" show r
+  , "  Expected: " ++ maybe "None" show e
+    ]
+prettyPrintParseException (NonStringKeyAlias n v) = unlines
+  [ "Non-string key alias:"
+  , "  Anchor name: " ++ n
+  , "  Value: " ++ show v 
 prettyPrintParseException pe = show pe
 
 newtype PErrorT m a = PErrorT { runPErrorT :: m (Either ParseException a) }


### PR DESCRIPTION
Using `yaml` sometimes I find unpleasant to read parse exceptions produced by `print`. The function implemented in this PR tries to mitigate this. It is incomplete, but I wanted to know if the idea is worth before spending more time with it.