### PR TITLE
Parse `Scientific` directly, avoiding loss in precision.

### DIFF
--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -37,10 +37,11 @@ import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.HashMap.Strict as M
 import Data.Typeable
-import Data.Text.Read
 #if MIN_VERSION_aeson(0, 7, 0)
-import Data.Scientific (fromFloatDigits)
+import qualified Data.Attoparsec.Text as Atto
+import Data.Scientific (Scientific)
 #else
+import Data.Text.Read
 import Data.Attoparsec.Number
 #endif
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
@@ -162,8 +163,7 @@ textToValue _ _ t
     | any (t `isLike`) ["y", "yes", "on", "true"] = Bool True
     | any (t `isLike`) ["n", "no", "off", "false"] = Bool False
 #if MIN_VERSION_aeson(0, 7, 0)
-    | Right (x, "") <- signed decimal t = Number $ fromIntegral (x :: Integer)
-    | Right (x, "") <- double t = Number $ fromFloatDigits x
+    | Right x <- textToScientific t = Number x
 #else
     | Right (x, "") <- signed decimal t = Number $ I x
     | Right (x, "") <- double t = Number $ D x
@@ -172,6 +172,10 @@ textToValue _ _ t
   where x `isLike` ref = x `elem` [ref, T.toUpper ref, titleCased]
           where titleCased = toUpper (T.head ref) `T.cons` T.tail ref
 
+#if MIN_VERSION_aeson(0, 7, 0)
+textToScientific :: Text -> Either String Scientific
+textToScientific = Atto.parseOnly (Atto.scientific <* Atto.endOfInput)
+#endif
 
 parseO :: C.Sink Event Parse Value
 parseO = do

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -48,7 +48,7 @@ library
                    , unordered-containers
                    , vector
                    , text
-                   , attoparsec
+                   , attoparsec >= 0.11.3.0
                    , scientific
                    , filepath
                    , directory


### PR DESCRIPTION
For example, before:

    λ> Yaml.decode "x: 9.78159610558926e-5" :: Maybe Yaml.Value
    Just (Object (fromList [("x",Number 9.781596105589261e-5)]))

after:

    λ> Yaml.decode "x: 9.78159610558926e-5" :: Maybe Yaml.Value
    Just (Object (fromList [("x",Number 9.78159610558926e-5)]))