### PR TITLE
Decode multi-document inputs. Issue #71

### DIFF
--- a/Data/Yaml.hs
+++ b/Data/Yaml.hs
@@ -45,11 +45,16 @@ module Data.Yaml
     , encode
     , encodeFile
     , decode
+    , decodeAll
     , decodeFile
+    , decodeAllFile
       -- ** Better error information
     , decodeEither
+    , decodeAllEither
     , decodeEither'
+    , decodeAllEither'
     , decodeFileEither
+    , decodeAllFileEither
       -- ** More control over decoding
     , decodeHelper
     ) where
@@ -151,10 +156,30 @@ decode bs = unsafePerformIO
           $ fmap (either (const Nothing) id)
           $ decodeHelper_ (Y.decode bs)
 
+decodeAll :: FromJSON a
+             => ByteString
+             -> Maybe [a]
+decodeAll bs
+  = unsafePerformIO $ do
+    res <- decodeHelperOneOrMany_ False (Y.decode bs)
+    return $ case res of
+              Left _ -> Nothing
+              Right xs -> Just xs
+
 decodeFile :: FromJSON a
            => FilePath
            -> IO (Maybe a)
 decodeFile fp = decodeHelper (Y.decodeFile fp) >>= either throwIO (return . either (const Nothing) id)
+
+decodeAllFile :: FromJSON a
+                 => FilePath
+                 -> IO (Maybe [a])
+decodeAllFile fp = do
+  res <- decodeHelperOneOrMany False (Y.decodeFile fp)
+  case res of
+   Left except -> throwIO except
+   Right (Left _) -> return Nothing
+   Right (Right ans) -> return $ Just ans
 
 -- | A version of 'decodeFile' which should not throw runtime exceptions.
 --
@@ -165,10 +190,24 @@ decodeFileEither
     -> IO (Either ParseException a)
 decodeFileEither = decodeHelper_ . Y.decodeFile
 
+decodeAllFileEither
+    :: FromJSON a
+    => FilePath
+    -> IO (Either ParseException [a])
+decodeAllFileEither = decodeHelperOneOrMany_ False . Y.decodeFile
+
 decodeEither :: FromJSON a => ByteString -> Either String a
 decodeEither bs = unsafePerformIO
                 $ fmap (either (Left . prettyPrintParseException) id)
                 $ decodeHelper (Y.decode bs)
+
+decodeAllEither :: FromJSON a => ByteString -> Either String [a]
+decodeAllEither bs
+  = unsafePerformIO $ do
+    res <- decodeHelperOneOrMany_ False (Y.decode bs)
+    return $ case res of
+              Left except -> Left $ prettyPrintParseException except
+              Right xs -> Right xs
 
 -- | More helpful version of 'decodeEither' which returns the 'YamlException'.
 --
@@ -178,6 +217,12 @@ decodeEither' = either Left (either (Left . AesonException) Right)
               . unsafePerformIO
               . decodeHelper
               . Y.decode
+
+decodeAllEither' :: FromJSON a => ByteString -> Either ParseException [a]
+decodeAllEither' = either Left (either (Left . AesonException) Right)
+                   . unsafePerformIO
+                   . decodeHelperOneOrMany False
+                   . Y.decode
 
 array :: [Value] -> Value
 array = Array . V.fromList

--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -50,7 +50,6 @@ import Data.Attoparsec.Number
 #endif
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import qualified Data.HashSet as HashSet
-import Data.Either
 
 data ParseException = NonScalarKey
                     | UnknownAlias { _anchorName :: Y.AnchorName }

--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -280,7 +280,10 @@ decodeHelper :: FromJSON a
 decodeHelper src = do
   res <- decodeHelperOneOrMany True src
   return $ case res of
-    (Right (Right [x])) -> Right (Right x)
+    -- head below is harmless since decodeHelperOneOrMany
+    -- with first argument True always returns a one-element
+    -- list on success
+    (Right (Right xs)) -> Right $ Right $ head xs
     (Right (Left s)) -> Right (Left s)
     (Left except) -> Left except
 
@@ -311,7 +314,10 @@ decodeHelper_ src
     res <- decodeHelperOneOrMany_ True src
     return $ case res of
               Left except -> Left except
-              Right [x] -> Right x
+              -- head below is harmless since decodeHelperOneOrMany_
+              -- with first argument True always returns a one-element
+              -- list on success
+              Right xs -> Right $ head xs
 
 -- | Strings which must be escaped so as not to be treated as non-string scalars.
 specialStrings :: HashSet.HashSet Text


### PR DESCRIPTION
The YAML specification allows an input stream to
contain multiple documents. We add functions
of the form decode*All to Data.Yaml to decode
these multi-document streams.