### PR TITLE
Add example usages

### DIFF
--- a/Data/Yaml.hs
+++ b/Data/Yaml.hs
@@ -16,6 +16,23 @@
 --
 -- For documentation on the @aeson@ types, functions, classes, and
 -- operators, please see the @Data.Aeson@ module of the @aeson@ package.
+--
+-- == Examples
+--
+-- Decode into a data structure by specifying the desired type to the 'decode'
+-- method.
+--
+-- > {-# LANGUAGE OverloadedStrings #-}
+-- >
+-- > import qualified Data.Yaml as Y
+-- >
+-- > main = do
+-- >   putStrLn . show $ (Y.decode "[1,2,3]" :: Maybe [Integer])
+--
+-- You can go one step further and decode into a custom type by implementing
+-- 'FromJSON' for that type. This is also appropriate where extra
+-- normalization, formatting or manipulation of the YAML is required on decode.
+
 #if (defined (ghcjs_HOST_OS))
 module Data.Yaml {-# WARNING "GHCJS is not supported yet (will break at runtime once called)." #-}
 #else

--- a/README.md
+++ b/README.md
@@ -3,19 +3,21 @@
 Provides support for parsing and emitting Yaml documents.
 
 This package includes the [full libyaml C library version 0.1.5 by Kirill
-Simonov](http://pyyaml.org/wiki/LibYAML) in the package so you
-don't need to worry about any non-Haskell dependencies.
+Simonov](http://pyyaml.org/wiki/LibYAML) in the package so you don't need to
+worry about any non-Haskell dependencies.
 
-The package is broken down into two primary modules.
-"Data.Yaml" provides a high-level interface based
-around the JSON datatypes provided by the @aeson@
-package. "Text.Libyaml" provides a lower-level,
-streaming interface. For most users, "Data.Yaml" is recommended.
+The package is broken down into two primary modules.  `Data.Yaml` provides a
+high-level interface based around the JSON datatypes provided by the `aeson`
+package. `Text.Libyaml` provides a lower-level, streaming interface. For most
+users, `Data.Yaml` is recommended.
 
-Usage examples can be found in the "Data.Yaml" documentation.
+Usage examples can be found in the `Data.Yaml` documentation.
 
 Additional modules:
 
-* Data.Yaml.Include supports adding `!include` directives to your YAML files.
-* DAta.Yaml.Builder and Data.Yaml.Parser allow more fine-grained control of parsing an rendering, as opposed to just using the aeson typeclass and datatype system for parsing and rendering.
-* Data.Yaml.Aeson is currently a re-export of Data.Yaml to explicitly choose to use the aeson-compatible API.
+* `Data.Yaml.Include` supports adding `!include` directives to your YAML files.
+* `Data.Yaml.Builder` and `Data.Yaml.Parser` allow more fine-grained control of
+  parsing an rendering, as opposed to just using the aeson typeclass and
+  datatype system for parsing and rendering.
+* `Data.Yaml.Aeson` is currently a re-export of `Data.Yaml` to explicitly
+  choose to use the aeson-compatible API.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ around the JSON datatypes provided by the @aeson@
 package. "Text.Libyaml" provides a lower-level,
 streaming interface. For most users, "Data.Yaml" is recommended.
 
+Usage examples can be found in the "Data.Yaml" documentation.
+
 Additional modules:
 
 * Data.Yaml.Include supports adding `!include` directives to your YAML files.


### PR DESCRIPTION
Addresses #78.

I am new to haskell and have no idea what I'm doing. Still to do:

* [x] Verify these examples are _valid_ code. This could be as easy as copy pasting them, but I want to see if doc tools can verify they compile first, or something fancy like that.
* [x] Verify these examples are _idiomatic_ code. Need some pro-haskellers in here.
* [x] Verify this is the right place for these examples. My intent is for them to show at https://hackage.haskell.org/package/yaml-0.8.16/docs/Data-Yaml.html
* [x] Is there a way to link directly to `FromJSON` docs when I mention it?
* [x] Figure out how to generate documentation locally and check that it renders properly, including the "examples" header and ToC. I briefly tried haddock and failed:

        > haddock Data/Yaml.hs

        Data/Yaml.hs:88:22:
             error: token is not a valid binary operator in a preprocessor subexpression
        #if !MIN_VERSION_base(4,8,0)
            ~~~~~~~~~~~~~~~~~^
        1 error generated.

Probably won't pick this up without pointers on the above because I'm already pretty deep in my yak stack and trying to work my way out :) If anyone else wants to (or just give me easy instructions) feel free.