### PR TITLE
optional depends: correction against pre-Cabal-1.24 bug

### DIFF
--- a/yaml.cabal
+++ b/yaml.cabal
@@ -142,15 +142,15 @@ executable examples
       Buildable: False
    else
       Buildable: True
+      build-depends: base
+                   , bytestring
+                   , raw-strings-qq
+                   , text
+                   , yaml
    hs-source-dirs: examples
    main-is: Main.hs
    other-modules: Config
                   Simple
-   build-depends: base
-                , bytestring
-                , raw-strings-qq
-                , text
-                , yaml
    ghc-options:   -Wall
 
 source-repository head


### PR DESCRIPTION
using current version of cabal `raw-strings-qq` will come in even with `no-examples` flag due bug in cabal, this condition correction is workaround