### PR TITLE
Fix pretty-printing order of UnexpectedEvent's fields (fixes #84)

### DIFF
--- a/Data/Yaml/Internal.hs
+++ b/Data/Yaml/Internal.hs
@@ -78,7 +78,7 @@ prettyPrintParseException :: ParseException -> String
 prettyPrintParseException pe = case pe of
   NonScalarKey -> "Non scalar key"
   UnknownAlias anchor -> "Unknown alias `" ++ anchor ++ "`"
-  UnexpectedEvent mbExpected mbUnexpected -> unlines
+  UnexpectedEvent { _expected = mbExpected, _received = mbUnexpected } -> unlines
     [ "Unexpected event: expected"
     , "  " ++ show mbExpected
     , "but received"


### PR DESCRIPTION
I didn't see tests for what error messages contain, so I'm not sure if you'd like a unit test with this, but I'm happy to add one if you say so.