### PR TITLE
Add `!include` syntax support for config file reading.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-## 0.8.17.3
+## 0.8.18
 
 * Switched yaml decode function for config file readers in `Data.Yaml.Config` to
   the one from `Data.Yaml.Include` that supports `!include` syntax.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.8.17.3
+
+* Switched yaml decode function for config file readers in `Data.Yaml.Config` to
+  the one from `Data.Yaml.Include` that supports `!include` syntax.
+
 ## 0.8.17.2
 
 * Fix pretty-printing order of UnexpectedEvent's fields (fixes [#84](https://github.com/snoyberg/yaml/issues/84)) [#85](https://github.com/snoyberg/yaml/pull/85)

--- a/Data/Yaml/Config.hs
+++ b/Data/Yaml/Config.hs
@@ -41,6 +41,7 @@ import Control.Monad (forM)
 import Control.Exception (throwIO)
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Yaml as Y
+import qualified Data.Yaml.Include as YI
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 
@@ -174,7 +175,7 @@ loadYamlSettings
     -> IO settings
 loadYamlSettings runTimeFiles compileValues envUsage = do
     runValues <- forM runTimeFiles $ \fp -> do
-        eres <- Y.decodeFileEither fp
+        eres <- YI.decodeFileEither fp
         case eres of
             Left e -> do
                 putStrLn $ "loadYamlSettings: Could not parse file as YAML: " ++ fp

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -1,5 +1,5 @@
 name:            yaml
-version:         0.8.17.2
+version:         0.8.17.3
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Anton Ageev <antage@gmail.com>,Kirill Simonov 

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -1,5 +1,5 @@
 name:            yaml
-version:         0.8.17.3
+version:         0.8.18
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Anton Ageev <antage@gmail.com>,Kirill Simonov 


### PR DESCRIPTION
Switched yaml decode function for config file readers to the one from `Data.Yaml.Include` that supports `!include` syntax. 
This change should be backwards compatible and should allow for multi package projects to mutually reuse config files.