### PR TITLE
Handle non-ASCII filenames correctly on Windows

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.8.18.2
+
+* Handle non-ASCII filenames correctly on Windows [#91](https://github.com/snoyberg/yaml/pull/91)
+
 ## 0.8.18.1
 
 * Improve prettyPrintParseException when context is empty [#89](https://github.com/snoyberg/yaml/pull/89)

--- a/Text/Libyaml.hs
+++ b/Text/Libyaml.hs
@@ -543,7 +543,6 @@ decodeFile file =
                 file' <- openFile file read_flags "r"
                 if file' == nullPtr
                     then do
-                        c_fclose_helper file'
                         c_yaml_parser_delete ptr
                         free ptr
                         throwIO $ YamlException

--- a/examples/Config.hs
+++ b/examples/Config.hs
@@ -9,6 +9,7 @@ import Data.Yaml (FromJSON(..), (.:))
 import Text.RawString.QQ
 import Data.ByteString (ByteString)
 import Control.Applicative
+import Prelude -- Ensure Applicative is in scope and we have no warnings, before/after AMP.
 
 configYaml :: ByteString
 configYaml = [r|

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -19,6 +19,7 @@ import Control.Monad
 import Control.Exception (try, SomeException)
 import Test.Hspec
 import Data.Either.Compat
+import System.Directory (createDirectory)
 import Test.Mockery.Directory
 
 import qualified Data.Yaml as D
@@ -63,6 +64,7 @@ spec = do
     describe "Data.Yaml" $ do
         it "encode/decode" caseEncodeDecodeData
         it "encode/decode file" caseEncodeDecodeFileData
+        it "encode/decode files with non-ASCII names" caseEncodeDecodeNonAsciiFileData
         it "encode/decode strings" caseEncodeDecodeStrings
         it "decode invalid file" caseDecodeInvalid
         it "processes datatypes" caseDataTypes
@@ -316,6 +318,17 @@ caseEncodeDecodeFileData = withFile "" $ \fp -> do
     D.encodeFile fp sample
     out <- D.decodeFile fp
     out @?= Just sample
+
+caseEncodeDecodeNonAsciiFileData :: Assertion
+caseEncodeDecodeNonAsciiFileData = do
+  let mySample = (object ["foo" .= True])
+  inTempDirectory $ do
+    createDirectory "accenté"
+    D.encodeFile "accenté/bar.yaml" mySample
+    out1 <- D.decodeFile "accenté/bar.yaml"
+    out1 @?= Just mySample
+  out2 <- D.decodeFile "test/resources/accenté/foo.yaml"
+  out2 @?= Just mySample
 
 caseEncodeDecodeStrings :: Assertion
 caseEncodeDecodeStrings = do

--- a/test/resources/accenté/foo.yaml
+++ b/test/resources/accenté/foo.yaml
@@ -1,0 +1,1 @@
+foo: true

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -1,5 +1,5 @@
 name:            yaml
-version:         0.8.18.1
+version:         0.8.18.2
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Anton Ageev <antage@gmail.com>,Kirill Simonov 

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -20,6 +20,7 @@ extra-source-files: c/helper.h
                     test/resources/foo.yaml
                     test/resources/bar.yaml
                     test/resources/baz.yaml
+                    test/resources/accenté/foo.yaml
                     test/resources/loop/foo.yaml
                     test/resources/loop/bar.yaml
                     README.md
@@ -130,6 +131,7 @@ test-suite spec
                    , text
                    , aeson >= 0.7
                    , unordered-containers
+                   , directory
                    , vector
                    , resourcet
                    , aeson-qq


### PR DESCRIPTION
Not yet finished, but I've confirmed this code fixes the bug on Windows. EDIT: at least with GHC 7.10.3. I'll add a test and rebase.