### PR TITLE
Workaround for exception-throwing canonicalizePath in old directory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.8.21.2
+
+* Fix wrong file not found exception in `Data.Yaml.Include` with pre-1.2.3.0 `directory` [#104](https://github.com/snoyberg/yaml/pull/104)
+
 ## 0.8.21.1
 
 * Add missing test files [#102](https://github.com/snoyberg/yaml/pull/102)

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -1,5 +1,5 @@
 name:            yaml
-version:         0.8.21.1
+version:         0.8.21.2
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Anton Ageev <antage@gmail.com>,Kirill Simonov


### PR DESCRIPTION
See: https://github.com/haskell/directory/issues/44#issuecomment-186575172

This makes the exception for nonexistent yaml files the same regardless of
which version of the directory package is used.