### PR TITLE
Update CPP MIN_VERSION_* checks

### DIFF
--- a/Data/Yaml.hs
+++ b/Data/Yaml.hs
@@ -78,7 +78,11 @@ import Data.Aeson
     , Object, Array
     , withObject, withText, withArray, withScientific, withBool
     )
+#if MIN_VERSION_aeson(1,0,0)
+import Data.Aeson.Text (encodeToTextBuilder)
+#else
 import Data.Aeson.Encode (encodeToTextBuilder)
+#endif
 import Data.Aeson.Types (Pair, parseMaybe, parseEither, Parser)
 import Data.ByteString (ByteString)
 import qualified Data.Conduit as C

--- a/Data/Yaml/Builder.hs
+++ b/Data/Yaml/Builder.hs
@@ -22,7 +22,11 @@ import Prelude hiding (null)
 
 import Control.Arrow (second)
 import Control.Monad.Trans.Resource (runResourceT)
+#if MIN_VERSION_aeson(1,0,0)
+import Data.Aeson.Text (encodeToTextBuilder)
+#else
 import Data.Aeson.Encode (encodeToTextBuilder)
+#endif
 import Data.Aeson.Types (Value(..))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as S8

--- a/Data/Yaml/Parser.hs
+++ b/Data/Yaml/Parser.hs
@@ -13,12 +13,7 @@ import Control.Monad.Trans.Resource (MonadThrow, monadThrow, runResourceT)
 import Control.Monad.Trans.Writer.Strict (tell, WriterT)
 import Data.ByteString (ByteString)
 import Data.Conduit
-#if MIN_VERSION_conduit(1,1,0)
 import Data.Conduit.Lift (runWriterC)
-#define runWriterSC runWriterC
-#else
-import Data.Conduit.Lift (runWriterSC)
-#endif
 import qualified Data.Map as Map
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid (..))
@@ -193,7 +188,7 @@ sinkValue =
             Just e -> monadThrow $ UnexpectedEvent e
 
 sinkRawDoc :: MonadThrow m => Consumer Event m RawDoc
-sinkRawDoc = uncurry RawDoc <$> runWriterSC sinkValue
+sinkRawDoc = uncurry RawDoc <$> runWriterC sinkValue
 
 readYamlFile :: FromYaml a => FilePath -> IO a
 readYamlFile fp = runResourceT (decodeFile fp $$ sinkRawDoc) >>= parseRawDoc


### PR DESCRIPTION
These changes remove `MIN_VERSION_conduit()` checks that will always be true, in order to remove clutter, and add `MIN_VERSION_aeson()` checks, in order to resolve deprecation warnings (and prevent unpleasant surprises with future aeson versions).

These changes should affect neither the interface nor the behaviour of this library.