### PR TITLE
#130, add LambdaCase to other-extensions

### DIFF
--- a/yaml.cabal
+++ b/yaml.cabal
@@ -45,6 +45,7 @@ flag no-unicode
   default: False
 
 library
+    other-extensions: LambdaCase
     build-depends:   base >= 4 && < 5
                    , transformers >= 0.1
                    , bytestring >= 0.9.1.4


### PR DESCRIPTION
As per #130, this PR adds LambdaCase to other-extensions, mirroring the change @hvr did as a revision to yaml-0.8.28.

I don't think this is worth mentioning in the changelog, and I don't suggest making a new release (the change needs to be made to the revision or the problem still arises - and once you've got a revision it doesn't help anyway).

I have not tested this patch locally, so recommend not merging until after the CI completes.