### PR TITLE
Removed AppSettings in error (Data/Yaml/Config.hs)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.8.30
+
+* Removed `AppSettings` mentioned in `loadYamlSettings` error message.
+
 ## 0.8.29
 
 * Deprecated `decodeFile` [#129](https://github.com/snoyberg/yaml/issues/129)

--- a/Data/Yaml/Config.hs
+++ b/Data/Yaml/Config.hs
@@ -195,7 +195,7 @@ loadYamlSettings runTimeFiles compileValues envUsage = do
             RequireCustomEnv env -> return $ applyEnvValue   True  env    value'
 
     case fromJSON value of
-        Error s -> error $ "Could not convert to AppSettings: " ++ s
+        Error s -> error $ "Could not convert: " ++ s
         Success settings -> return settings
 
 -- | Same as @loadYamlSettings@, but get the list of runtime config files from

--- a/Data/Yaml/Config.hs
+++ b/Data/Yaml/Config.hs
@@ -195,7 +195,7 @@ loadYamlSettings runTimeFiles compileValues envUsage = do
             RequireCustomEnv env -> return $ applyEnvValue   True  env    value'
 
     case fromJSON value of
-        Error s -> error $ "Could not convert: " ++ s
+        Error s -> error $ "Could not convert to expected type: " ++ s
         Success settings -> return settings
 
 -- | Same as @loadYamlSettings@, but get the list of runtime config files from

--- a/yaml.cabal
+++ b/yaml.cabal
@@ -1,5 +1,5 @@
 name:            yaml
-version:         0.8.29
+version:         0.8.30
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Anton Ageev <antage@gmail.com>,Kirill Simonov


### PR DESCRIPTION
`loadYamlSettings` isn't only used for AppSettings, so having that in the error message can be confusing.