### PR TITLE
Expose tags and styles for sequences and mappings in Text.Libyaml

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yaml
 
+## 0.9.0
+
+* Expose style and tags on mappings and sequences in Text.Libyaml [#141](https://github.com/snoyberg/yaml/pull/141)
+
 ## 0.8.32
 
 * Escape keys as necessary [#137](https://github.com/snoyberg/yaml/issues/137)

--- a/c/helper.c
+++ b/c/helper.c
@@ -128,6 +128,16 @@ unsigned char * get_sequence_start_anchor(yaml_event_t *e)
         return e->data.sequence_start.anchor;
 }
 
+unsigned char * get_sequence_start_tag(yaml_event_t *e)
+{
+        return e->data.sequence_start.tag;
+}
+
+unsigned long get_sequence_start_tag_len(yaml_event_t *e)
+{
+	return strlen((char *) get_sequence_start_tag(e));
+}
+
 unsigned char * get_mapping_start_anchor(yaml_event_t *e)
 {
         return e->data.mapping_start.anchor;

--- a/c/helper.c
+++ b/c/helper.c
@@ -133,6 +133,16 @@ unsigned char * get_mapping_start_anchor(yaml_event_t *e)
         return e->data.mapping_start.anchor;
 }
 
+unsigned char * get_mapping_start_tag(yaml_event_t *e)
+{
+        return e->data.mapping_start.tag;
+}
+
+unsigned long get_mapping_start_tag_len(yaml_event_t *e)
+{
+	return strlen((char *) get_mapping_start_tag(e));
+}
+
 unsigned char * get_alias_anchor(yaml_event_t *e)
 {
         return e->data.alias.anchor;

--- a/c/helper.c
+++ b/c/helper.c
@@ -128,9 +128,16 @@ unsigned char * get_sequence_start_anchor(yaml_event_t *e)
         return e->data.sequence_start.anchor;
 }
 
+int get_sequence_start_style(yaml_event_t *e)
+{
+	return e->data.sequence_start.style;
+}
+
 unsigned char * get_sequence_start_tag(yaml_event_t *e)
 {
-        return e->data.sequence_start.tag;
+	unsigned char *s = e->data.sequence_start.tag;
+	if (!s) s = (unsigned char *) "";
+	return s;
 }
 
 unsigned long get_sequence_start_tag_len(yaml_event_t *e)
@@ -143,9 +150,16 @@ unsigned char * get_mapping_start_anchor(yaml_event_t *e)
         return e->data.mapping_start.anchor;
 }
 
+int get_mapping_start_style(yaml_event_t *e)
+{
+	return e->data.mapping_start.style;
+}
+
 unsigned char * get_mapping_start_tag(yaml_event_t *e)
 {
-        return e->data.mapping_start.tag;
+	unsigned char *s = e->data.mapping_start.tag;
+	if (!s) s = (unsigned char *) "";
+	return s;
 }
 
 unsigned long get_mapping_start_tag_len(yaml_event_t *e)

--- a/c/helper.c
+++ b/c/helper.c
@@ -108,11 +108,6 @@ unsigned char * get_scalar_tag(yaml_event_t *e)
 	return s;
 }
 
-unsigned long get_scalar_tag_len(yaml_event_t *e)
-{
-	return strlen((char *) get_scalar_tag(e));
-}
-
 int get_scalar_style(yaml_event_t *e)
 {
 	return e->data.scalar.style;
@@ -140,11 +135,6 @@ unsigned char * get_sequence_start_tag(yaml_event_t *e)
 	return s;
 }
 
-unsigned long get_sequence_start_tag_len(yaml_event_t *e)
-{
-	return strlen((char *) get_sequence_start_tag(e));
-}
-
 unsigned char * get_mapping_start_anchor(yaml_event_t *e)
 {
         return e->data.mapping_start.anchor;
@@ -160,11 +150,6 @@ unsigned char * get_mapping_start_tag(yaml_event_t *e)
 	unsigned char *s = e->data.mapping_start.tag;
 	if (!s) s = (unsigned char *) "";
 	return s;
-}
-
-unsigned long get_mapping_start_tag_len(yaml_event_t *e)
-{
-	return strlen((char *) get_mapping_start_tag(e));
 }
 
 unsigned char * get_alias_anchor(yaml_event_t *e)

--- a/c/helper.h
+++ b/c/helper.h
@@ -29,6 +29,8 @@ unsigned long get_scalar_length(yaml_event_t *e);
 
 unsigned char * get_scalar_tag(yaml_event_t *e);
 unsigned long get_scalar_tag_len(yaml_event_t *e);
+unsigned char * get_sequence_start_tag(yaml_event_t *e);
+unsigned long get_sequence_start_tag_len(yaml_event_t *e);
 unsigned char * get_mapping_start_tag(yaml_event_t *e);
 unsigned long get_mapping_start_tag_len(yaml_event_t *e);
 

--- a/c/helper.h
+++ b/c/helper.h
@@ -28,11 +28,8 @@ unsigned char * get_scalar_value(yaml_event_t *e);
 unsigned long get_scalar_length(yaml_event_t *e);
 
 unsigned char * get_scalar_tag(yaml_event_t *e);
-unsigned long get_scalar_tag_len(yaml_event_t *e);
 unsigned char * get_sequence_start_tag(yaml_event_t *e);
-unsigned long get_sequence_start_tag_len(yaml_event_t *e);
 unsigned char * get_mapping_start_tag(yaml_event_t *e);
-unsigned long get_mapping_start_tag_len(yaml_event_t *e);
 
 int get_scalar_style(yaml_event_t *e);
 int get_sequence_start_style(yaml_event_t *e);

--- a/c/helper.h
+++ b/c/helper.h
@@ -29,6 +29,8 @@ unsigned long get_scalar_length(yaml_event_t *e);
 
 unsigned char * get_scalar_tag(yaml_event_t *e);
 unsigned long get_scalar_tag_len(yaml_event_t *e);
+unsigned char * get_mapping_start_tag(yaml_event_t *e);
+unsigned long get_mapping_start_tag_len(yaml_event_t *e);
 
 int get_scalar_style(yaml_event_t *e);
 

--- a/c/helper.h
+++ b/c/helper.h
@@ -35,6 +35,8 @@ unsigned char * get_mapping_start_tag(yaml_event_t *e);
 unsigned long get_mapping_start_tag_len(yaml_event_t *e);
 
 int get_scalar_style(yaml_event_t *e);
+int get_sequence_start_style(yaml_event_t *e);
+int get_mapping_start_style(yaml_event_t *e);
 
 unsigned char * get_scalar_anchor(yaml_event_t *e);
 unsigned char * get_sequence_start_anchor(yaml_event_t *e);

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        yaml
-version:     0.8.32
+version:     0.9.0
 synopsis:    Support for parsing and rendering YAML documents.
 description: README and API documentation are available at <https://www.stackage.org/package/yaml>
 category:    Data

--- a/src/Data/Yaml.hs
+++ b/src/Data/Yaml.hs
@@ -135,7 +135,7 @@ objToEvents' (Array list) rest =
     EventSequenceStart Nothing
   : foldr objToEvents' (EventSequenceEnd : rest) (V.toList list)
 objToEvents' (Object pairs) rest =
-    EventMappingStart Nothing
+    EventMappingStart MapTag Nothing
   : foldr pairToEvents (EventMappingEnd : rest) (M.toList pairs)
 
 -- Empty strings need special handling to ensure they get quoted. This avoids:

--- a/src/Data/Yaml.hs
+++ b/src/Data/Yaml.hs
@@ -132,10 +132,10 @@ scalarToEvent (YamlScalar v t s) = EventScalar v t s Nothing
 objToEvents' :: Value -> [Y.Event] -> [Y.Event]
 --objToEvents' (Scalar s) rest = scalarToEvent s : rest
 objToEvents' (Array list) rest =
-    EventSequenceStart NoTag Nothing
+    EventSequenceStart NoTag Any Nothing
   : foldr objToEvents' (EventSequenceEnd : rest) (V.toList list)
 objToEvents' (Object pairs) rest =
-    EventMappingStart NoTag Nothing
+    EventMappingStart NoTag Any Nothing
   : foldr pairToEvents (EventMappingEnd : rest) (M.toList pairs)
 
 -- Empty strings need special handling to ensure they get quoted. This avoids:

--- a/src/Data/Yaml.hs
+++ b/src/Data/Yaml.hs
@@ -132,10 +132,10 @@ scalarToEvent (YamlScalar v t s) = EventScalar v t s Nothing
 objToEvents' :: Value -> [Y.Event] -> [Y.Event]
 --objToEvents' (Scalar s) rest = scalarToEvent s : rest
 objToEvents' (Array list) rest =
-    EventSequenceStart NoTag Any Nothing
+    EventSequenceStart NoTag AnySequence Nothing
   : foldr objToEvents' (EventSequenceEnd : rest) (V.toList list)
 objToEvents' (Object pairs) rest =
-    EventMappingStart NoTag Any Nothing
+    EventMappingStart NoTag AnyMapping Nothing
   : foldr pairToEvents (EventMappingEnd : rest) (M.toList pairs)
 
 -- Empty strings need special handling to ensure they get quoted. This avoids:

--- a/src/Data/Yaml.hs
+++ b/src/Data/Yaml.hs
@@ -132,10 +132,10 @@ scalarToEvent (YamlScalar v t s) = EventScalar v t s Nothing
 objToEvents' :: Value -> [Y.Event] -> [Y.Event]
 --objToEvents' (Scalar s) rest = scalarToEvent s : rest
 objToEvents' (Array list) rest =
-    EventSequenceStart Nothing
+    EventSequenceStart NoTag Nothing
   : foldr objToEvents' (EventSequenceEnd : rest) (V.toList list)
 objToEvents' (Object pairs) rest =
-    EventMappingStart MapTag Nothing
+    EventMappingStart NoTag Nothing
   : foldr pairToEvents (EventMappingEnd : rest) (M.toList pairs)
 
 -- Empty strings need special handling to ensure they get quoted. This avoids:

--- a/src/Data/Yaml/Builder.hs
+++ b/src/Data/Yaml/Builder.hs
@@ -62,7 +62,7 @@ instance ToYaml Int where
 
 mapping :: [(Text, YamlBuilder)] -> YamlBuilder
 mapping pairs = YamlBuilder $ \rest ->
-    EventMappingStart NoTag Any Nothing : foldr addPair (EventMappingEnd : rest) pairs
+    EventMappingStart NoTag AnyMapping Nothing : foldr addPair (EventMappingEnd : rest) pairs
   where
     addPair (key, YamlBuilder value) after
         = EventScalar (encodeUtf8 key) StrTag PlainNoTag Nothing
@@ -70,7 +70,7 @@ mapping pairs = YamlBuilder $ \rest ->
 
 array :: [YamlBuilder] -> YamlBuilder
 array bs =
-    YamlBuilder $ (EventSequenceStart NoTag Any Nothing:) . flip (foldr go) bs . (EventSequenceEnd:)
+    YamlBuilder $ (EventSequenceStart NoTag AnySequence Nothing:) . flip (foldr go) bs . (EventSequenceEnd:)
   where
     go (YamlBuilder b) = b
 

--- a/src/Data/Yaml/Builder.hs
+++ b/src/Data/Yaml/Builder.hs
@@ -62,7 +62,7 @@ instance ToYaml Int where
 
 mapping :: [(Text, YamlBuilder)] -> YamlBuilder
 mapping pairs = YamlBuilder $ \rest ->
-    EventMappingStart MapTag Nothing : foldr addPair (EventMappingEnd : rest) pairs
+    EventMappingStart NoTag Any Nothing : foldr addPair (EventMappingEnd : rest) pairs
   where
     addPair (key, YamlBuilder value) after
         = EventScalar (encodeUtf8 key) StrTag PlainNoTag Nothing
@@ -70,7 +70,7 @@ mapping pairs = YamlBuilder $ \rest ->
 
 array :: [YamlBuilder] -> YamlBuilder
 array bs =
-    YamlBuilder $ (EventSequenceStart NoTag Nothing:) . flip (foldr go) bs . (EventSequenceEnd:)
+    YamlBuilder $ (EventSequenceStart NoTag Any Nothing:) . flip (foldr go) bs . (EventSequenceEnd:)
   where
     go (YamlBuilder b) = b
 

--- a/src/Data/Yaml/Builder.hs
+++ b/src/Data/Yaml/Builder.hs
@@ -70,7 +70,7 @@ mapping pairs = YamlBuilder $ \rest ->
 
 array :: [YamlBuilder] -> YamlBuilder
 array bs =
-    YamlBuilder $ (EventSequenceStart Nothing:) . flip (foldr go) bs . (EventSequenceEnd:)
+    YamlBuilder $ (EventSequenceStart NoTag Nothing:) . flip (foldr go) bs . (EventSequenceEnd:)
   where
     go (YamlBuilder b) = b
 

--- a/src/Data/Yaml/Builder.hs
+++ b/src/Data/Yaml/Builder.hs
@@ -62,7 +62,7 @@ instance ToYaml Int where
 
 mapping :: [(Text, YamlBuilder)] -> YamlBuilder
 mapping pairs = YamlBuilder $ \rest ->
-    EventMappingStart Nothing : foldr addPair (EventMappingEnd : rest) pairs
+    EventMappingStart MapTag Nothing : foldr addPair (EventMappingEnd : rest) pairs
   where
     addPair (key, YamlBuilder value) after
         = EventScalar (encodeUtf8 key) StrTag PlainNoTag Nothing

--- a/src/Data/Yaml/Internal.hs
+++ b/src/Data/Yaml/Internal.hs
@@ -195,8 +195,8 @@ parseO = do
     me <- CL.head
     case me of
         Just (EventScalar v tag style a) -> textToValue style tag <$> parseScalar v a style tag
-        Just (EventSequenceStart _ a) -> parseS a id
-        Just (EventMappingStart _ a) -> parseM a M.empty
+        Just (EventSequenceStart _ _ a) -> parseS a id
+        Just (EventMappingStart _ _ a) -> parseM a M.empty
         Just (EventAlias an) -> do
             m <- lift get
             case Map.lookup an m of

--- a/src/Data/Yaml/Internal.hs
+++ b/src/Data/Yaml/Internal.hs
@@ -196,7 +196,7 @@ parseO = do
     case me of
         Just (EventScalar v tag style a) -> textToValue style tag <$> parseScalar v a style tag
         Just (EventSequenceStart a) -> parseS a id
-        Just (EventMappingStart a) -> parseM a M.empty
+        Just (EventMappingStart _ a) -> parseM a M.empty
         Just (EventAlias an) -> do
             m <- lift get
             case Map.lookup an m of

--- a/src/Data/Yaml/Internal.hs
+++ b/src/Data/Yaml/Internal.hs
@@ -195,7 +195,7 @@ parseO = do
     me <- CL.head
     case me of
         Just (EventScalar v tag style a) -> textToValue style tag <$> parseScalar v a style tag
-        Just (EventSequenceStart a) -> parseS a id
+        Just (EventSequenceStart _ a) -> parseS a id
         Just (EventMappingStart _ a) -> parseM a M.empty
         Just (EventAlias an) -> do
             m <- lift get

--- a/src/Data/Yaml/Parser.hs
+++ b/src/Data/Yaml/Parser.hs
@@ -162,11 +162,11 @@ sinkValue =
     go EventDocumentStart = start
     go (EventAlias a) = return $ Alias a
     go (EventScalar a b c d) = tell' d $ Scalar a b c d
-    go (EventSequenceStart _tag mname) = do
+    go (EventSequenceStart _tag _style mname) = do
         vals <- goS id
         let val = Sequence vals mname
         tell' mname val
-    go (EventMappingStart _tag mname) = do
+    go (EventMappingStart _tag _style mname) = do
         pairs <- goM id
         let val = Mapping pairs mname
         tell' mname val

--- a/src/Data/Yaml/Parser.hs
+++ b/src/Data/Yaml/Parser.hs
@@ -162,7 +162,7 @@ sinkValue =
     go EventDocumentStart = start
     go (EventAlias a) = return $ Alias a
     go (EventScalar a b c d) = tell' d $ Scalar a b c d
-    go (EventSequenceStart mname) = do
+    go (EventSequenceStart _tag mname) = do
         vals <- goS id
         let val = Sequence vals mname
         tell' mname val

--- a/src/Data/Yaml/Parser.hs
+++ b/src/Data/Yaml/Parser.hs
@@ -166,7 +166,7 @@ sinkValue =
         vals <- goS id
         let val = Sequence vals mname
         tell' mname val
-    go (EventMappingStart mname) = do
+    go (EventMappingStart _tag mname) = do
         pairs <- goM id
         let val = Mapping pairs mname
         tell' mname val

--- a/src/Text/Libyaml.hs
+++ b/src/Text/Libyaml.hs
@@ -259,23 +259,18 @@ foreign import ccall unsafe "get_mapping_start_tag"
 foreign import ccall unsafe "get_alias_anchor"
     c_get_alias_anchor :: EventRaw -> IO CString
 
-readAnchor :: (EventRaw -> IO CString) -> (EventRaw -> IO Anchor)
+readAnchor :: (EventRaw -> IO CString) -> EventRaw -> IO Anchor
 readAnchor getAnchor er = do
   yanchor <- getAnchor er
   if yanchor == nullPtr
     then return Nothing
     else Just <$> peekCString yanchor
 
-readStyle :: (Enum a) => (EventRaw -> IO CInt) -> (EventRaw -> IO a)
-readStyle getStyle er = do
-  ystyle <- getStyle er
-  return $ toEnum $ fromEnum ystyle
+readStyle :: (Enum a) => (EventRaw -> IO CInt) -> EventRaw -> IO a
+readStyle getStyle er = toEnum . fromEnum <$> getStyle er 
 
 readTag :: (EventRaw -> IO (Ptr CUChar)) -> EventRaw -> IO Tag
-readTag getTag er = do
-  ytag <- getTag er
-  let ytag' = castPtr ytag
-  bsToTag <$> packCString ytag'
+readTag getTag er = bsToTag <$> (getTag er >>= packCString . castPtr) 
 
 getEvent :: EventRaw -> IO (Maybe Event)
 getEvent er = do

--- a/src/Text/Libyaml.hs
+++ b/src/Text/Libyaml.hs
@@ -14,6 +14,8 @@ module Text.Libyaml
     ( -- * The event stream
       Event (..)
     , Style (..)
+    , SequenceStyle (..)
+    , MappingStyle (..)
     , Tag (..)
     , AnchorName
     , Anchor
@@ -62,9 +64,9 @@ data Event =
     | EventDocumentEnd
     | EventAlias !AnchorName
     | EventScalar !ByteString !Tag !Style !Anchor
-    | EventSequenceStart !Tag !Style !Anchor
+    | EventSequenceStart !Tag !SequenceStyle !Anchor
     | EventSequenceEnd
-    | EventMappingStart !Tag !Style !Anchor
+    | EventMappingStart !Tag !MappingStyle !Anchor
     | EventMappingEnd
     deriving (Show, Eq)
 
@@ -76,6 +78,12 @@ data Style = Any
            | Folded
            | PlainNoTag
     deriving (Show, Read, Eq, Enum, Bounded, Ord, Data, Typeable)
+
+data SequenceStyle = AnySequence | BlockSequence | FlowSequence
+    deriving (Show, Eq, Enum, Bounded, Ord, Data, Typeable)
+
+data MappingStyle = AnyMapping | BlockMapping | FlowMapping
+    deriving (Show, Eq, Enum, Bounded, Ord, Data, Typeable)
 
 data Tag = StrTag
          | FloatTag
@@ -260,7 +268,7 @@ readAnchor getAnchor er = do
     then return Nothing
     else Just <$> peekCString yanchor
 
-readStyle :: (EventRaw -> IO CInt) -> (EventRaw -> IO Style)
+readStyle :: (Enum a) => (EventRaw -> IO CInt) -> (EventRaw -> IO a)
 readStyle getStyle er = do
   ystyle <- getStyle er
   return $ toEnum $ fromEnum ystyle

--- a/src/Text/Libyaml.hs
+++ b/src/Text/Libyaml.hs
@@ -79,9 +79,11 @@ data Style = Any
            | PlainNoTag
     deriving (Show, Read, Eq, Enum, Bounded, Ord, Data, Typeable)
 
+-- @since 0.9.0
 data SequenceStyle = AnySequence | BlockSequence | FlowSequence
     deriving (Show, Eq, Enum, Bounded, Ord, Data, Typeable)
 
+-- @since 0.9.0
 data MappingStyle = AnyMapping | BlockMapping | FlowMapping
     deriving (Show, Eq, Enum, Bounded, Ord, Data, Typeable)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,3 @@ resolver: lts-11.10
 flags:
   yaml:
     no-examples: false
-
-docker:
-  enable: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,6 @@ resolver: lts-11.10
 flags:
   yaml:
     no-examples: false
+
+docker:
+  enable: true

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -65,6 +65,8 @@ spec = do
         it "count mappings with anchor" caseCountMappingsWithAnchor
         it "count sequences with custom tag" caseCountSequenceTags
         it "count mappings with custom tag" caseCountMappingTags
+        it "count count sequences with ! tag" caseCountEmptySequenceTags
+        it "count count mappings with ! tag" caseCountEmptyMappingTags
         it "count block style sequences" caseCountBlockStyleSequences
         it "count flow style sequences" caseCountFlowStyleSequences
         it "count block style mappings" caseCountBlockStyleMappings
@@ -263,12 +265,28 @@ caseCountMappingTags =
     isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!bar") _ _) = True
     isCustomTaggedMapping _ = False
 
+caseCountEmptyMappingTags :: Assertion
+caseCountEmptyMappingTags =
+    caseHelper yamlString isCustomTaggedMapping 1
+  where
+    yamlString = "foo: !\n  k: v\n  k2: v2"
+    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!") _ _) = True
+    isCustomTaggedMapping _ = False
+
 caseCountSequenceTags :: Assertion
 caseCountSequenceTags =
     caseHelper yamlString isCustomTaggedSequence 1
   where
     yamlString = "foo: !bar [x, y, z]"
     isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!bar") _ _) = True
+    isCustomTaggedSequence _ = False
+
+caseCountEmptySequenceTags :: Assertion
+caseCountEmptySequenceTags =
+    caseHelper yamlString isCustomTaggedSequence 1
+  where
+    yamlString = "foo: !\n  k: v\n  k2: v2"
+    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!") _ _) = True
     isCustomTaggedSequence _ = False
 
 caseCountFlowStyleSequences :: Assertion

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -238,7 +238,7 @@ caseCountMappingsWithAnchor =
     caseHelper yamlString isMappingA 1
   where
     yamlString = "foo: &anchor\n  key1: bin1\n  key2: bin2\n  key3: bin3"
-    isMappingA (Y.EventMappingStart (Just _)) = True
+    isMappingA (Y.EventMappingStart _ (Just _)) = True
     isMappingA _ = False
 
 caseCountAliases :: Assertion

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -230,7 +230,7 @@ caseCountSequencesWithAnchor =
     caseHelper yamlString isSequenceStartA 1
   where
     yamlString = "foo: &anchor\n  - bin1\n  - bin2\n  - bin3"
-    isSequenceStartA (Y.EventSequenceStart (Just _)) = True
+    isSequenceStartA (Y.EventSequenceStart Y.NoTag (Just _)) = True
     isSequenceStartA _ = False
 
 caseCountMappingsWithAnchor :: Assertion

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -63,6 +63,8 @@ spec = do
         it "count scalars with anchor" caseCountScalarsWithAnchor
         it "count sequences with anchor" caseCountSequencesWithAnchor
         it "count mappings with anchor" caseCountMappingsWithAnchor
+        it "count sequences with custom tag" caseCountSequenceTags
+        it "count mappings with custom tag" caseCountMappingTags
         it "count aliases" caseCountAliases
         it "count scalars" caseCountScalars
         it "largest string" caseLargestString
@@ -248,6 +250,22 @@ caseCountAliases =
     yamlString = "foo: &anchor\n  key1: bin1\n  key2: bin2\n  key3: bin3\nboo: *anchor"
     isAlias Y.EventAlias{} = True
     isAlias _ = False
+
+caseCountMappingTags :: Assertion
+caseCountMappingTags =
+    caseHelper yamlString isCustomTaggedMapping 1
+  where
+    yamlString = "foo: !bar\n  k: v\n  k2: v2"
+    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!bar") _) = True
+    isCustomTaggedMapping _ = False
+
+caseCountSequenceTags :: Assertion
+caseCountSequenceTags =
+    caseHelper yamlString isCustomTaggedSequence 1
+  where
+    yamlString = "foo: !bar [x, y, z]"
+    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!bar") _) = True
+    isCustomTaggedSequence _ = False
 
 caseCountScalars :: Assertion
 caseCountScalars = do

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -65,6 +65,10 @@ spec = do
         it "count mappings with anchor" caseCountMappingsWithAnchor
         it "count sequences with custom tag" caseCountSequenceTags
         it "count mappings with custom tag" caseCountMappingTags
+        it "count block style sequences" caseCountBlockStyleSequences
+        it "count flow style sequences" caseCountFlowStyleSequences
+        it "count block style mappings" caseCountBlockStyleMappings
+        it "count flow style mappings" caseCountFlowStyleMappings
         it "count aliases" caseCountAliases
         it "count scalars" caseCountScalars
         it "largest string" caseLargestString
@@ -266,6 +270,38 @@ caseCountSequenceTags =
     yamlString = "foo: !bar [x, y, z]"
     isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!bar") _ _) = True
     isCustomTaggedSequence _ = False
+
+caseCountFlowStyleSequences :: Assertion
+caseCountFlowStyleSequences =
+    caseHelper yamlString isFlowStyleSequence 1
+  where
+    yamlString = "foo: [x, y, z]"
+    isFlowStyleSequence (Y.EventSequenceStart _ Y.FlowSequence _) = True
+    isFlowStyleSequence _ = False
+
+caseCountBlockStyleSequences :: Assertion
+caseCountBlockStyleSequences =
+    caseHelper yamlString isBlockStyleSequence 1
+  where
+    yamlString = "foo:\n- x\n- y\n- z\n"
+    isBlockStyleSequence (Y.EventSequenceStart _ Y.BlockSequence _) = True
+    isBlockStyleSequence _ = False
+
+caseCountFlowStyleMappings :: Assertion
+caseCountFlowStyleMappings =
+    caseHelper yamlString isFlowStyleMapping 1
+  where
+    yamlString = "foo: { bar: 1, baz: 2 }"
+    isFlowStyleMapping (Y.EventMappingStart _ Y.FlowMapping _) = True
+    isFlowStyleMapping _ = False
+
+caseCountBlockStyleMappings :: Assertion
+caseCountBlockStyleMappings =
+    caseHelper yamlString isBlockStyleMapping 1
+  where
+    yamlString = "foo: bar\nbaz: quux"
+    isBlockStyleMapping (Y.EventMappingStart _ Y.BlockMapping _) = True
+    isBlockStyleMapping _ = False
 
 caseCountScalars :: Assertion
 caseCountScalars = do

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -232,7 +232,7 @@ caseCountSequencesWithAnchor =
     caseHelper yamlString isSequenceStartA 1
   where
     yamlString = "foo: &anchor\n  - bin1\n  - bin2\n  - bin3"
-    isSequenceStartA (Y.EventSequenceStart Y.NoTag (Just _)) = True
+    isSequenceStartA (Y.EventSequenceStart Y.NoTag _ (Just _)) = True
     isSequenceStartA _ = False
 
 caseCountMappingsWithAnchor :: Assertion
@@ -240,7 +240,7 @@ caseCountMappingsWithAnchor =
     caseHelper yamlString isMappingA 1
   where
     yamlString = "foo: &anchor\n  key1: bin1\n  key2: bin2\n  key3: bin3"
-    isMappingA (Y.EventMappingStart _ (Just _)) = True
+    isMappingA (Y.EventMappingStart _ _ (Just _)) = True
     isMappingA _ = False
 
 caseCountAliases :: Assertion
@@ -256,7 +256,7 @@ caseCountMappingTags =
     caseHelper yamlString isCustomTaggedMapping 1
   where
     yamlString = "foo: !bar\n  k: v\n  k2: v2"
-    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!bar") _) = True
+    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!bar") _ _) = True
     isCustomTaggedMapping _ = False
 
 caseCountSequenceTags :: Assertion
@@ -264,7 +264,7 @@ caseCountSequenceTags =
     caseHelper yamlString isCustomTaggedSequence 1
   where
     yamlString = "foo: !bar [x, y, z]"
-    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!bar") _) = True
+    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!bar") _ _) = True
     isCustomTaggedSequence _ = False
 
 caseCountScalars :: Assertion

--- a/test/Data/YamlSpec.hs
+++ b/test/Data/YamlSpec.hs
@@ -285,7 +285,7 @@ caseCountEmptySequenceTags :: Assertion
 caseCountEmptySequenceTags =
     caseHelper yamlString isCustomTaggedSequence 1
   where
-    yamlString = "foo: !\n  k: v\n  k2: v2"
+    yamlString = "foo: ! [x, y, z]"
     isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!") _ _) = True
     isCustomTaggedSequence _ = False
 


### PR DESCRIPTION
This makes tag and style information available on sequences and mappings as well as scalars (at the Text.Libyaml layer - it is not propagated anywhere else).

*This would break code using Text.Libyaml because it adds extra fields into the `Event` data structure.*

```haskell
    EventSequenceStart !Tag !SequenceStyle !Anchor
    EventMappingStart !Tag !MappingStyle !Anchor
```

...however, I think this is the only sensible way to expose this information. It's definitely an omission at present (although it might very well be an intentional one!). The `Tag` data type includes `MapTag` and `SeqTag` but they'd never be used because tags on mappings and sequences are simply ignored.