### PR TITLE
Export `objToEvents`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yaml
 
+## 0.10.3.0
+
+* Expose `objToEvents` to allow more control on the generation of Yaml events. [#156](https://github.com/snoyberg/yaml/pull/156)
+
 ## 0.10.2.0
 
 * Add `EncodeOptions` and `FormatOptions` to control the style of the encoded YAML. [#153](https://github.com/snoyberg/yaml/pull/153)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        yaml
-version:     0.10.2.0
+version:     0.10.3.0
 synopsis:    Support for parsing and rendering YAML documents.
 description: README and API documentation are available at <https://www.stackage.org/package/yaml>
 category:    Data

--- a/src/Data/Yaml.hs
+++ b/src/Data/Yaml.hs
@@ -69,6 +69,7 @@ module Data.Yaml
     , ToJSON (..)
     , FromJSON (..)
       -- * Custom encoding
+    , objToEvents
     , isSpecialString
     , EncodeOptions
     , defaultEncodeOptions

--- a/src/Data/Yaml.hs
+++ b/src/Data/Yaml.hs
@@ -196,6 +196,9 @@ encodeFileWith opts fp obj = runConduitRes
     $ CL.sourceList (objToEvents opts $ toJSON obj)
    .| Y.encodeFileWith (encodeOptionsFormat opts) fp
 
+-- | Encode a JSON value into a list of YAML events
+--
+-- @since 0.10.3.0
 objToEvents :: EncodeOptions -> Value -> [Y.Event]
 objToEvents opts o = (:) EventStreamStart
               . (:) EventDocumentStart


### PR DESCRIPTION
Use-case: fixing [this](https://github.com/dhall-lang/dhall-json/issues/58) issue requires that we output many Yaml documents instead of only one (currently hardcoded [here](https://github.com/snoyberg/yaml/blob/master/src/Data/Yaml.hs#L199)).

Since the library only exposes the low-level (`Libyaml`) and the high-level (`encode`, put value get string), `objToEvents` is the missing piece to be able to manipulate events without having to reimplement `objToEvents'`.

So just exposing it would be fine and it's the simplest fix possible, but if we want to go the extra mile and output a list of documents, I could change the signature of `objToEvents` to `EncodeOptions -> [Value] -> [Y.Event]`, but that would require some additional changes (and API breakage as well I guess).