### PR TITLE
Close #157. Return start and end marks for all events.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for yaml
 
+## 0.10.4.0
+
+* Add `decodeMarked` and `decodeFileMarked` functions to `Text.Libyaml`, and
+  extend native bindings to extract mark information. [#157](https://github.com/snoyberg/yaml/issues/157)
+
 ## 0.10.3.0
 
 * Add support for anchors and aliases to Data.Yaml.Builder [#155](https://github.com/snoyberg/yaml/pull/155)

--- a/c/helper.c
+++ b/c/helper.c
@@ -56,19 +56,9 @@ char const * get_parser_error_context(yaml_parser_t *p)
 	return p->context;
 }
 
-unsigned int get_parser_error_index(yaml_parser_t *p)
+const yaml_mark_t * get_parser_error_mark(yaml_parser_t *p)
 {
-	return p->problem_mark.index;
-}
-
-unsigned int get_parser_error_line(yaml_parser_t *p)
-{
-	return p->problem_mark.line;
-}
-
-unsigned int get_parser_error_column(yaml_parser_t *p)
-{
-	return p->problem_mark.column;
+	return &p->problem_mark;
 }
 
 char const * get_emitter_error(yaml_emitter_t *e)
@@ -155,6 +145,31 @@ unsigned char * get_mapping_start_tag(yaml_event_t *e)
 unsigned char * get_alias_anchor(yaml_event_t *e)
 {
         return e->data.alias.anchor;
+}
+
+const yaml_mark_t * get_start_mark(yaml_event_t *e)
+{
+	return &e->start_mark;
+}
+
+const yaml_mark_t * get_end_mark(yaml_event_t *e)
+{
+	return &e->end_mark;
+}
+
+unsigned int get_mark_index(yaml_mark_t *m)
+{
+	return m->index;
+}
+
+unsigned int get_mark_line(yaml_mark_t *m)
+{
+	return m->line;
+}
+
+unsigned int get_mark_column(yaml_mark_t *m)
+{
+	return m->column;
 }
 
 int yaml_parser_set_input_filename(yaml_parser_t *parser, const char *filename)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        yaml
-version:     0.10.3.0
+version:     0.10.4.0
 synopsis:    Support for parsing and rendering YAML documents.
 description: README and API documentation are available at <https://www.stackage.org/package/yaml>
 category:    Data

--- a/src/Text/Libyaml.hs
+++ b/src/Text/Libyaml.hs
@@ -79,7 +79,7 @@ data Event =
 
 -- | Event with start and end marks.
 --
--- @since [INSERTVERSION]
+-- @since 0.10.4.0
 data MarkedEvent = MarkedEvent
     { yamlEvent     :: Event
     , yamlStartMark :: YamlMark
@@ -552,11 +552,16 @@ newtype ToEventRawException = ToEventRawException CInt
     deriving (Show, Typeable)
 instance Exception ToEventRawException
 
+-- | Create a conduit that yields events from a bytestring.
 decode :: MonadResource m => B.ByteString -> ConduitM i Event m ()
 decode = mapOutput yamlEvent . decodeMarked
 
--- |
--- @since [INSERTVERSION]
+-- | Create a conduit that yields marked events from a bytestring.
+--
+-- This conduit will yield identical events to that of "decode", but also
+-- includes start and end marks for each event.
+--
+-- @since 0.10.4.0
 decodeMarked :: MonadResource m => B.ByteString -> ConduitM i MarkedEvent m ()
 decodeMarked bs | B8.null bs = return ()
 decodeMarked bs =
@@ -599,11 +604,16 @@ openFile file rawOpenFlags openMode = do
     then withCString openMode $ \openMode' -> c_fdopen fd openMode'
     else return nullPtr
 
+-- | Creata a conduit that yields events from a file.
 decodeFile :: MonadResource m => FilePath -> ConduitM i Event m ()
 decodeFile = mapOutput yamlEvent . decodeFileMarked
 
--- |
--- @since [INSERTVERSION]
+-- | Create a conduit that yields marked events from a file.
+--
+-- This conduit will yield identical events to that of "decodeFile", but also
+-- includes start and end marks for each event.
+--
+-- @since 0.10.4.0
 decodeFileMarked :: MonadResource m => FilePath -> ConduitM i MarkedEvent m ()
 decodeFileMarked file =
     bracketP alloc cleanup (runParser . fst)


### PR DESCRIPTION
Adds `decodeMarked` and `decodeFileMarked` functions, which return conduits yielding `MarkedEvent` instances.