### PR TITLE
Prevent sequence & mapping tags from being ignored

### DIFF
--- a/yaml/src/Data/Yaml.hs
+++ b/yaml/src/Data/Yaml.hs
@@ -206,10 +206,10 @@ objToEvents opts o = (:) EventStreamStart
     objToEvents' :: Value -> [Y.Event] -> [Y.Event]
     --objToEvents' (Scalar s) rest = scalarToEvent s : rest
     objToEvents' (Array list) rest =
-        EventSequenceStart NoTag AnySequence Nothing
+        EventSequenceStart NoTag TagOptional AnySequence Nothing
       : foldr objToEvents' (EventSequenceEnd : rest) (V.toList list)
     objToEvents' (Object pairs) rest =
-        EventMappingStart NoTag AnyMapping Nothing
+        EventMappingStart NoTag TagOptional AnyMapping Nothing
       : foldr pairToEvents (EventMappingEnd : rest) (M.toList pairs)
 
     objToEvents' (String "") rest = EventScalar "" NoTag SingleQuoted Nothing : rest

--- a/yaml/src/Data/Yaml/Builder.hs
+++ b/yaml/src/Data/Yaml/Builder.hs
@@ -81,7 +81,7 @@ instance ToYaml Int where
 -- @since 0.11.0
 maybeNamedMapping :: Maybe Text -> [(Text, YamlBuilder)] -> YamlBuilder
 maybeNamedMapping anchor pairs = YamlBuilder $ \rest ->
-    EventMappingStart NoTag AnyMapping (unpack <$> anchor) : foldr addPair (EventMappingEnd : rest) pairs
+    EventMappingStart NoTag TagOptional AnyMapping (unpack <$> anchor) : foldr addPair (EventMappingEnd : rest) pairs
   where
     addPair (key, YamlBuilder value) after
         = EventScalar (encodeUtf8 key) StrTag PlainNoTag Nothing
@@ -99,7 +99,7 @@ namedMapping name = maybeNamedMapping $ Just name
 -- @since 0.11.0
 maybeNamedArray :: Maybe Text -> [YamlBuilder] -> YamlBuilder
 maybeNamedArray anchor bs =
-    YamlBuilder $ (EventSequenceStart NoTag AnySequence (unpack <$> anchor):) . flip (foldr go) bs . (EventSequenceEnd:)
+    YamlBuilder $ (EventSequenceStart NoTag TagOptional AnySequence (unpack <$> anchor):) . flip (foldr go) bs . (EventSequenceEnd:)
   where
     go (YamlBuilder b) = b
 

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -203,8 +203,8 @@ parseO = do
     me <- lift CL.head
     case me of
         Just (EventScalar v tag style a) -> textToValue style tag <$> parseScalar v a style tag
-        Just (EventSequenceStart _ _ a) -> parseS 0 a id
-        Just (EventMappingStart _ _ a) -> parseM mempty a M.empty
+        Just (EventSequenceStart _ _ _ a) -> parseS 0 a id
+        Just (EventMappingStart _ _ _ a) -> parseM mempty a M.empty
         Just (EventAlias an) -> do
             m <- lookupAnchor an
             case m of

--- a/yaml/src/Data/Yaml/Parser.hs
+++ b/yaml/src/Data/Yaml/Parser.hs
@@ -162,11 +162,11 @@ sinkValue =
     go EventDocumentStart = start
     go (EventAlias a) = return $ Alias a
     go (EventScalar a b c d) = tell' d $ Scalar a b c d
-    go (EventSequenceStart _tag _style mname) = do
+    go (EventSequenceStart _tag _tag_disp _style mname) = do
         vals <- goS id
         let val = Sequence vals mname
         tell' mname val
-    go (EventMappingStart _tag _style mname) = do
+    go (EventMappingStart _tag _tag_disp _style mname) = do
         pairs <- goM id
         let val = Mapping pairs mname
         tell' mname val

--- a/yaml/test/Data/YamlSpec.hs
+++ b/yaml/test/Data/YamlSpec.hs
@@ -239,7 +239,7 @@ caseCountSequencesWithAnchor =
     caseHelper yamlString isSequenceStartA 1
   where
     yamlString = "foo: &anchor\n  - bin1\n  - bin2\n  - bin3"
-    isSequenceStartA (Y.EventSequenceStart Y.NoTag _ (Just _)) = True
+    isSequenceStartA (Y.EventSequenceStart Y.NoTag _ _ (Just _)) = True
     isSequenceStartA _ = False
 
 caseCountMappingsWithAnchor :: Assertion
@@ -247,7 +247,7 @@ caseCountMappingsWithAnchor =
     caseHelper yamlString isMappingA 1
   where
     yamlString = "foo: &anchor\n  key1: bin1\n  key2: bin2\n  key3: bin3"
-    isMappingA (Y.EventMappingStart _ _ (Just _)) = True
+    isMappingA (Y.EventMappingStart _ _ _ (Just _)) = True
     isMappingA _ = False
 
 caseCountAliases :: Assertion
@@ -263,7 +263,7 @@ caseCountMappingTags =
     caseHelper yamlString isCustomTaggedMapping 1
   where
     yamlString = "foo: !bar\n  k: v\n  k2: v2"
-    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!bar") _ _) = True
+    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!bar") _ _ _) = True
     isCustomTaggedMapping _ = False
 
 caseCountEmptyMappingTags :: Assertion
@@ -271,7 +271,7 @@ caseCountEmptyMappingTags =
     caseHelper yamlString isCustomTaggedMapping 1
   where
     yamlString = "foo: !\n  k: v\n  k2: v2"
-    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!") _ _) = True
+    isCustomTaggedMapping (Y.EventMappingStart (Y.UriTag "!") _ _ _) = True
     isCustomTaggedMapping _ = False
 
 caseCountSequenceTags :: Assertion
@@ -279,7 +279,7 @@ caseCountSequenceTags =
     caseHelper yamlString isCustomTaggedSequence 1
   where
     yamlString = "foo: !bar [x, y, z]"
-    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!bar") _ _) = True
+    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!bar") _ _ _) = True
     isCustomTaggedSequence _ = False
 
 caseCountEmptySequenceTags :: Assertion
@@ -287,7 +287,7 @@ caseCountEmptySequenceTags =
     caseHelper yamlString isCustomTaggedSequence 1
   where
     yamlString = "foo: ! [x, y, z]"
-    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!") _ _) = True
+    isCustomTaggedSequence (Y.EventSequenceStart (Y.UriTag "!") _ _ _) = True
     isCustomTaggedSequence _ = False
 
 caseCountFlowStyleSequences :: Assertion
@@ -295,7 +295,7 @@ caseCountFlowStyleSequences =
     caseHelper yamlString isFlowStyleSequence 1
   where
     yamlString = "foo: [x, y, z]"
-    isFlowStyleSequence (Y.EventSequenceStart _ Y.FlowSequence _) = True
+    isFlowStyleSequence (Y.EventSequenceStart _ _ Y.FlowSequence _) = True
     isFlowStyleSequence _ = False
 
 caseCountBlockStyleSequences :: Assertion
@@ -303,7 +303,7 @@ caseCountBlockStyleSequences =
     caseHelper yamlString isBlockStyleSequence 1
   where
     yamlString = "foo:\n- x\n- y\n- z\n"
-    isBlockStyleSequence (Y.EventSequenceStart _ Y.BlockSequence _) = True
+    isBlockStyleSequence (Y.EventSequenceStart _ _ Y.BlockSequence _) = True
     isBlockStyleSequence _ = False
 
 caseCountFlowStyleMappings :: Assertion
@@ -311,7 +311,7 @@ caseCountFlowStyleMappings =
     caseHelper yamlString isFlowStyleMapping 1
   where
     yamlString = "foo: { bar: 1, baz: 2 }"
-    isFlowStyleMapping (Y.EventMappingStart _ Y.FlowMapping _) = True
+    isFlowStyleMapping (Y.EventMappingStart _ _ Y.FlowMapping _) = True
     isFlowStyleMapping _ = False
 
 caseCountBlockStyleMappings :: Assertion
@@ -319,7 +319,7 @@ caseCountBlockStyleMappings =
     caseHelper yamlString isBlockStyleMapping 1
   where
     yamlString = "foo: bar\nbaz: quux"
-    isBlockStyleMapping (Y.EventMappingStart _ Y.BlockMapping _) = True
+    isBlockStyleMapping (Y.EventMappingStart _ _ Y.BlockMapping _) = True
     isBlockStyleMapping _ = False
 
 caseCountScalars :: Assertion


### PR DESCRIPTION
So turns out #141 wasn't as effective as I'd hoped. (i.e. at all).

While it certainly allowed tags to be specified against mappings and sequences and passed them into libyaml C, there was an "implicit" parameter was hardcoded to 1 in Libyaml.hs which was causing libyaml C to treat them all as optional and ignore them.

Tried a couple of approaches to fixing this. 

First off, we _could_ further overload the Style enums to encode this information as well, like we're already doing in `Plain` vs `PlainNoTag` in the scalar style... and then maybe hide away the factoring out of the "implicit" parameter (i.e. this ickiness...

```haskell
                    let (pi, style) =
                            case style0 of
                                PlainNoTag -> (1, Plain)
                                x -> (0, x)
``` 
)

...into a type class to slightly clean up the calling code.

But I think, even if the libyaml C API is a bit wonky here, trying to simplify it by stuffing these concerns together into the same data types is just muddying the waters further. We could end up with other tangles to unpick further down the line.

So I think this PR is the better approach: just expose the "implicit" parameter in the Event data type, even if it does involve changing the Event type once more and add in a field that few people will need.

There are still some awkwardnesses:
- this is really only meaningful for render; on read it defaults to `TagOptional` just for to be extra safe for compatibility
- I've put some tests in YamlSpec that really belong in a LibyamlSpec - but there isn't one
- feels wrong to not to clean this up in the Scalar case too, but that's rather more confounded (two different "implicit" parameters with tight relationships to the style values) and probably much riskier

I'm only using Libyaml so I haven't given much thought to the Data.Yaml side of things beyond trying to ensure nothing breaks.

In case sequence and mapping tags seem like a bit of an esoteric corner case, they are actually quite heavily used in AWS CloudFormation for example (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-join.html).