### PR TITLE
Do not print a error message in loadYamlSettings

### DIFF
--- a/yaml/ChangeLog.md
+++ b/yaml/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yaml
 
+## 0.11.0.2
+
+* Add `LoadSettingsException` exception and remove error printing from `loadYamlSettings` [#172](https://github.com/snoyberg/yaml/pull/172)
+
 ## 0.11.0.1
 
 * Better error messages in the `Data.Yaml.Config` module [#168](https://github.com/snoyberg/yaml/issues/168)

--- a/yaml/package.yaml
+++ b/yaml/package.yaml
@@ -1,5 +1,5 @@
 name:        yaml
-version:     0.11.0.1
+version:     0.11.0.2
 synopsis:    Support for parsing and rendering YAML documents.
 description: README and API documentation are available at <https://www.stackage.org/package/yaml>
 category:    Data

--- a/yaml/src/Data/Yaml/Config.hs
+++ b/yaml/src/Data/Yaml/Config.hs
@@ -180,9 +180,7 @@ loadYamlSettings runTimeFiles compileValues envUsage = do
     runValues <- forM runTimeFiles $ \fp -> do
         eres <- YI.decodeFileEither fp
         case eres of
-            Left e -> do
-                putStrLn $ "loadYamlSettings: Could not parse file as YAML: " ++ fp
-                throwIO e
+            Left e -> throwIO (Y.LoadSettingsException fp e)
             Right value -> return value
 
     value' <-

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -62,6 +62,7 @@ data ParseException = NonScalarKey
                     | OtherParseException SomeException
                     | NonStringKeyAlias Y.AnchorName Value
                     | CyclicIncludes
+                    | LoadSettingsException FilePath ParseException
     deriving (Show, Typeable)
 
 instance Exception ParseException where
@@ -113,6 +114,7 @@ prettyPrintParseException pe = case pe of
     , "  Value: " ++ show value
     ]
   CyclicIncludes -> "Cyclic includes"
+  LoadSettingsException fp exc -> "Could not parse file as YAML: " ++ fp ++ "\n" ++ prettyPrintParseException exc
 
 defineAnchor :: Value -> String -> ReaderT JSONPath (ConduitM e o Parse) ()
 defineAnchor value name = modify (modifyAnchors $ Map.insert name value)


### PR DESCRIPTION
While implementing the `Data.Yaml.Config` module I was stumbling over the this hardcoded `putStrLn` statement and I think it should be left to the user of the `yaml` library to decide how to handle exception and not print anything to `stdout`.

If I missed something and the `putStrLn` statement is worth keeping just ignore me and close the PR.

Thanks for you're awesome work!