### PR TITLE
Expose function for encoding YAML events

### DIFF
--- a/yaml/ChangeLog.md
+++ b/yaml/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yaml
 
+## 0.11.2.0
+
+* Add `objToEvents` function for encoding values as YAML events
+
 ## 0.11.1.2
 
 * Compiles with GHC 8.8.1 (`MonadFail` split)

--- a/yaml/package.yaml
+++ b/yaml/package.yaml
@@ -1,5 +1,5 @@
 name:        yaml
-version:     0.11.1.2
+version:     0.11.2.0
 synopsis:    Support for parsing and rendering YAML documents.
 description: README and API documentation are available at <https://www.stackage.org/package/yaml>
 category:    Data


### PR DESCRIPTION
I'd like to expose a function for encoding raw YAML events for a project I'm working on. I'm not entirely sure it should be exposed from this module, but happy to refactor if you'd prefer something else.