### PR TITLE
Reduce duplication between encode and encodePretty

### DIFF
--- a/yaml/ChangeLog.md
+++ b/yaml/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog for yaml
 
+## 0.11.2.0
+
+* Reduces some of the code duplication between the `encode` and `encodePretty` functions
+* The output of `encodePretty` has been improved:
+    - Multiline strings now use `Literal` style instead of `SingleQuoted`
+    - Special keys are now quoted in maps [#179](https://github.com/snoyberg/yaml/issues/179)
+
 ## 0.11.1.2
 
 * Compiles with GHC 8.8.1 (`MonadFail` split)

--- a/yaml/src/Data/Yaml/Pretty.hs
+++ b/yaml/src/Data/Yaml/Pretty.hs
@@ -10,6 +10,7 @@ module Data.Yaml.Pretty
     , getConfDropNull
     , setConfDropNull
     , defConfig
+    , pretty
     ) where
 
 import Prelude hiding (null)
@@ -34,7 +35,7 @@ import Data.Yaml.Builder
 -- @since 0.8.13
 data Config = Config
   { confCompare :: Text -> Text -> Ordering -- ^ Function used to sort keys in objects
-  , confDropNull :: Bool
+  , confDropNull :: Bool -- ^ Drop null values from objects
   }
 
 -- | The default configuration: do not sort objects or drop keys


### PR DESCRIPTION
Moves `objToStream` to `Data.Yaml.Internal` to reduce some of the code duplication between the `encode` and `encodePretty` functions.

The output of `encodePretty` has been improved:
- Multiline strings now use `Literal` style instead of `SingleQuoted`
- Special keys are now quoted in maps (resolves #179)

----

I did some property based testing of the two encoders (not included in this PR) to make sure that there weren't any other regressions, which is how I came across #179.

There's still a fair bit of duplication between `encode` and `encodePretty`, but it's hard to reduce further without making breaking changes to `encodePretty`. It would be possible to extend [`Data.Yaml.EncodeOptions`](http://hackage.haskell.org/package/yaml-0.11.1.2/docs/Data-Yaml.html#t:EncodeOptions) to support all the formatting options of [`Data.Yaml.Pretty.Config`](http://hackage.haskell.org/package/yaml-0.11.1.2/docs/Data-Yaml-Pretty.html#t:Config), in which case the `Pretty` module could be deprecated and removed, but I thought I would leave that out of this PR for now.