### PR TITLE
Complex keys in mappings

### DIFF
--- a/yaml/ChangeLog.md
+++ b/yaml/ChangeLog.md
@@ -5,7 +5,11 @@
 * Reduces some of the code duplication between the `encode` and `encodePretty` functions
 * The output of `encodePretty` has been improved:
     - Multiline strings now use `Literal` style instead of `SingleQuoted`
-    - Special keys are now quoted in maps [#179](https://github.com/snoyberg/yaml/issues/179)
+    - Special keys are now quoted in mappings [#179](https://github.com/snoyberg/yaml/issues/179)
+* Support for complex keys in mappings: [#182](https://github.com/snoyberg/yaml/issues/182)
+    - Adds `complexMapping` function to `Data.Yaml.Builder`
+    - Decode functions now return a `NonStringKey` error when attempting to decode a mapping with a complex key as it is not possible to decode these to an Aeson `Value`
+* Adds missing `ToYaml` instances
 
 ## 0.11.1.2
 

--- a/yaml/src/Data/Yaml/Builder.hs
+++ b/yaml/src/Data/Yaml/Builder.hs
@@ -78,17 +78,19 @@ instance ToYaml Int where
     toYaml i = YamlBuilder (EventScalar (S8.pack $ show i) NoTag PlainNoTag Nothing:)
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 maybeNamedMapping :: Maybe Text -> [(Text, YamlBuilder)] -> YamlBuilder
 maybeNamedMapping anchor pairs = maybeNamedMappingComplex anchor complexPairs
   where
     complexPairs = map (\(k, v) -> (string k, v)) pairs
 
+-- |
+-- @since 0.8.7
 mapping :: [(Text, YamlBuilder)] -> YamlBuilder
 mapping = maybeNamedMapping Nothing
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 namedMapping :: Text -> [(Text, YamlBuilder)] -> YamlBuilder
 namedMapping name = maybeNamedMapping $ Just name
 
@@ -111,81 +113,93 @@ namedMappingComplex :: Text -> [(YamlBuilder, YamlBuilder)] -> YamlBuilder
 namedMappingComplex name = maybeNamedMappingComplex $ Just name
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 maybeNamedArray :: Maybe Text -> [YamlBuilder] -> YamlBuilder
 maybeNamedArray anchor bs =
     YamlBuilder $ (EventSequenceStart NoTag AnySequence (unpack <$> anchor):) . flip (foldr go) bs . (EventSequenceEnd:)
   where
     go (YamlBuilder b) = b
 
+-- |
+-- @since 0.8.7
 array :: [YamlBuilder] -> YamlBuilder
 array = maybeNamedArray Nothing
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 namedArray :: Text -> [YamlBuilder] -> YamlBuilder
 namedArray name = maybeNamedArray $ Just name
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 maybeNamedString :: Maybe Text -> Text -> YamlBuilder
 maybeNamedString anchor s = YamlBuilder (stringScalar defaultStringStyle anchor s :)
 
+-- |
+-- @since 0.8.7
 string :: Text -> YamlBuilder
 string = maybeNamedString Nothing
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 namedString :: Text -> Text -> YamlBuilder
 namedString name = maybeNamedString $ Just name
  
 -- Use aeson's implementation which gets rid of annoying decimal points
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 maybeNamedScientific :: Maybe Text -> Scientific -> YamlBuilder
 maybeNamedScientific anchor n = YamlBuilder (EventScalar (TE.encodeUtf8 $ TL.toStrict $ toLazyText $ encodeToTextBuilder (Number n)) NoTag PlainNoTag (unpack <$> anchor) :)
 
+-- |
+-- @since 0.8.13
 scientific :: Scientific -> YamlBuilder
 scientific = maybeNamedScientific Nothing
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 namedScientific :: Text -> Scientific -> YamlBuilder
 namedScientific name = maybeNamedScientific $ Just name
 
+-- |
+-- @since 0.8.13
 {-# DEPRECATED number "Use scientific" #-}
 number :: Scientific -> YamlBuilder
 number = scientific
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 maybeNamedBool :: Maybe Text -> Bool -> YamlBuilder
 maybeNamedBool anchor True   = YamlBuilder (EventScalar "true" NoTag PlainNoTag (unpack <$> anchor) :)
 maybeNamedBool anchor False  = YamlBuilder (EventScalar "false" NoTag PlainNoTag (unpack <$> anchor) :)
 
+-- |
+-- @since 0.8.13
 bool :: Bool -> YamlBuilder
 bool = maybeNamedBool Nothing
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 namedBool :: Text -> Bool -> YamlBuilder
 namedBool name = maybeNamedBool $ Just name
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 maybeNamedNull :: Maybe Text -> YamlBuilder
 maybeNamedNull anchor = YamlBuilder (EventScalar "null" NoTag PlainNoTag (unpack <$> anchor) :)
 
+-- |
+-- @since 0.8.13
 null :: YamlBuilder
 null = maybeNamedNull Nothing
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 namedNull :: Text -> YamlBuilder
 namedNull name = maybeNamedNull $ Just name
 
 -- |
--- @since 0.11.0
+-- @since 0.10.3.0
 alias :: Text -> YamlBuilder
 alias anchor = YamlBuilder (EventAlias (unpack anchor) :)
 
@@ -196,6 +210,8 @@ toEvents (YamlBuilder front) =
 toSource :: (Monad m, ToYaml a) => a -> ConduitM i Event m ()
 toSource = mapM_ yield . toEvents . toYaml
 
+-- |
+-- @since 0.8.7
 toByteString :: ToYaml a => a -> ByteString
 toByteString = toByteStringWith defaultFormatOptions
 

--- a/yaml/src/Data/Yaml/Builder.hs
+++ b/yaml/src/Data/Yaml/Builder.hs
@@ -51,6 +51,7 @@ import qualified Data.ByteString.Char8 as S8
 import Data.Conduit
 import Data.Scientific (Scientific)
 import Data.Text (Text, unpack)
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
 import Data.Text.Lazy.Builder (toLazyText)
@@ -74,8 +75,18 @@ instance ToYaml a => ToYaml [a] where
     toYaml = array . map toYaml
 instance ToYaml Text where
     toYaml = string
+instance ToYaml String where
+    toYaml = string . T.pack
 instance ToYaml Int where
     toYaml i = YamlBuilder (EventScalar (S8.pack $ show i) NoTag PlainNoTag Nothing:)
+instance ToYaml Double where
+    toYaml i = YamlBuilder (EventScalar (S8.pack $ show i) NoTag PlainNoTag Nothing:)
+instance ToYaml Scientific where
+    toYaml = scientific
+instance ToYaml Bool where
+    toYaml = bool
+instance ToYaml a => ToYaml (Maybe a) where
+    toYaml = maybe null toYaml
 
 -- |
 -- @since 0.10.3.0

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -31,7 +31,7 @@ import Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import Control.Monad.State.Strict
 import Control.Monad.Reader
 import Data.Aeson
-import Data.Aeson.Internal (JSONPath, JSONPathElement(..))
+import Data.Aeson.Internal (JSONPath, JSONPathElement(..), formatError)
 import Data.Aeson.Types hiding (parse)
 import qualified Data.Attoparsec.Text as Atto
 import Data.Bits (shiftL, (.|.))
@@ -68,6 +68,7 @@ data ParseException = NonScalarKey
                     | InvalidYaml (Maybe YamlException)
                     | AesonException String
                     | OtherParseException SomeException
+                    | NonStringKey JSONPath
                     | NonStringKeyAlias Y.AnchorName Value
                     | CyclicIncludes
                     | LoadSettingsException FilePath ParseException
@@ -116,6 +117,7 @@ prettyPrintParseException pe = case pe of
         ]
   AesonException s -> "Aeson exception:\n" ++ s
   OtherParseException exc -> "Generic parse exception:\n" ++ show exc
+  NonStringKey path -> formatError path "Non-string keys are not supported"
   NonStringKeyAlias anchor value -> unlines
     [ "Non-string key alias:"
     , "  Anchor name: " ++ anchor
@@ -258,7 +260,9 @@ parseM mergedKeys a front = do
                             Nothing -> liftIO $ throwIO $ UnknownAlias an
                             Just (String t) -> return t
                             Just v -> liftIO $ throwIO $ NonStringKeyAlias an v
-                    _ -> liftIO $ throwIO $ UnexpectedEvent me Nothing
+                    _ -> do
+                        path <- ask
+                        liftIO $ throwIO $ NonStringKey path
 
             (mergedKeys', al') <- local (Key s :) $ do
               o <- parseO

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -329,7 +329,7 @@ defaultStringStyle = \s ->
       ()
         | "\n" `T.isInfixOf` s -> ( NoTag, Literal )
         | isSpecialString s -> ( NoTag, SingleQuoted )
-        | otherwise -> ( StrTag, PlainNoTag )
+        | otherwise -> ( NoTag, PlainNoTag )
 
 -- | Determine whether a string must be quoted in YAML and can't appear as plain text.
 -- Useful if you want to use 'setStringStyle'.


### PR DESCRIPTION
Resolves #182 and fixes a couple of other things I noticed while looking at the code:

- Adds support for complex keys in mappings to `Data.Yaml.Builder`
- Decode functions now return a `NonStringKey` error when attempting to decode a mapping with a complex key as it is not possible to decode these to an Aeson `Value`
- Corrects some `@since` annotations for `Data.Yaml.Builder`
- Adds missing `ToYaml` instances

This should wrap up the changes I've been looking at making. I've been assuming the next version will be `0.11.2.0` in the `@since` annotations and changelog but I haven't bumped the version, please let me know if you would like me to add a commit for that.