### PR TITLE
Fix #195: options --help and --version

### DIFF
--- a/yaml/exe/yaml2json.hs
+++ b/yaml/exe/yaml2json.hs
@@ -1,31 +1,96 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
 import Prelude hiding (putStr, getContents)
 
-import Data.Aeson (encode, Value)
-import Data.ByteString (getContents)
+import Data.Aeson           (encode, Value)
+import Data.ByteString      (getContents)
 import Data.ByteString.Lazy (putStr)
-import System.Environment (getArgs)
+import Data.List            (intercalate)
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup       (Semigroup(..))
+#endif
+import Data.Version         (Version(versionBranch))
+import Data.Yaml            (decodeFileEither, decodeEither')
+
+import Options.Applicative
+  ( Parser
+  , action, execParser, header, help, helper, hidden
+  , info, infoOption, long, metavar, short, strArgument
+  )
+
 import System.Exit
-import System.IO (stderr, hPutStrLn)
+import System.IO (stderr, hPrint)
 
-import Data.Yaml (decodeFileEither, decodeEither')
+import qualified Paths_yaml as Paths
 
-helpMessage :: IO ()
-helpMessage = putStrLn "Usage: yaml2json FILE\n\nuse '-' as FILE to indicate stdin" >> exitFailure
+newtype Options = Options
+  { optInput :: Maybe FilePath
+      -- ^ Nothing means @stdin@.
+  }
+
+-- | Name of the executable.
+
+self :: String
+self = "yaml2json"
+
+-- | Homepage for this program.
+
+homepage :: String
+homepage = "https://github.com/snoyberg/yaml/"
+
+-- | Version in @x.y.z@ format.
+
+version :: String
+version = intercalate "." $ map show $ versionBranch Paths.version
+
+-- | Parse options; handle parse errors, @--help@, @--version@.
+
+options :: IO Options
+options =
+  execParser $
+    info (helper <*> versionOption <*> numericVersionOption <*> programOptions)
+         (header "Reads given YAML document and prints it JSON format to standard out.")
+
+  where
+  versionOption =
+    infoOption (unwords versionWords)
+      $  long "version"
+      <> short 'V'
+      <> hidden
+      <> help "Show version info."
+  versionWords = [ self, "version", version, homepage ]
+
+  numericVersionOption =
+    infoOption version
+      $  long "numeric-version"
+      <> hidden
+      <> help "Show just version number."
+
+  programOptions = Options <$> oInput
+
+  oInput :: Parser (Maybe FilePath)
+  oInput = dashToStdin <$> do
+    strArgument
+      $  metavar "FILE"
+      <> action "file"
+      <> help "The input file containing the YAML document; use '-' for stdin."
+    where
+    -- dash is interpreted as stdin
+    dashToStdin = \case
+          "-"  -> Nothing
+          file -> Just file
 
 showJSON :: Show a => Either a Value -> IO b
-showJSON ejson =
-    case ejson of
-       Left err -> hPutStrLn stderr (show err) >> exitFailure
-       Right res -> putStr (encode (res :: Value)) >> exitSuccess
+showJSON = \case
+  Left  err -> hPrint stderr err >> exitFailure
+  Right res -> putStr (encode (res :: Value)) >> exitSuccess
 
 main :: IO ()
 main = do
-    args <- getArgs
-    case args of
-       -- strict getContents will read in all of stdin at once
-       (["-h"]) -> helpMessage
-       (["--help"]) -> helpMessage
-       (["-"]) -> getContents >>= showJSON . decodeEither'
-       ([f])   -> decodeFileEither f >>= showJSON
-       _ -> helpMessage
-
+  Options{ optInput } <- options
+  showJSON =<< case optInput of
+    -- strict getContents will read in all of stdin at once
+    Nothing -> decodeEither' <$> getContents
+    Just f  -> decodeFileEither f

--- a/yaml/package.yaml
+++ b/yaml/package.yaml
@@ -72,10 +72,15 @@ executables:
     main: yaml2json.hs
     source-dirs: exe
     dependencies:
+    - optparse-applicative
     - yaml
     when:
     - condition: flag(no-exe)
       buildable: false
+    other-extensions:
+    - CPP
+    - LambdaCase
+    - NamedFieldPuns
   examples:
     main: Main.hs
     source-dirs: examples

--- a/yaml/package.yaml
+++ b/yaml/package.yaml
@@ -34,7 +34,7 @@ flags:
     default: true
 
 dependencies:
-- base >=4.9.1 && <5 # GHC 8.0.2 and later
+- base >=4.9.1 && <5 # GHC 8.0.2 and later, meaning that Data.Semigroup is in base
 - bytestring >=0.9.1.4
 - transformers >=0.1
 - mtl
@@ -51,15 +51,12 @@ dependencies:
 - directory
 - template-haskell
 - libyaml >=0.1 && <0.2
-when:
-  condition: "!impl(ghc >= 8.0)"
-  dependencies:
-  - semigroups
+
+ghc-options: -Wall -Wcompat
 
 library:
   other-extensions:
   - LambdaCase
-  ghc-options: -Wall
   source-dirs: src
 
 executables:
@@ -82,7 +79,6 @@ executables:
   examples:
     main: Main.hs
     source-dirs: examples
-    ghc-options: -Wall
     when:
     - condition: flag(no-examples)
       then:
@@ -96,7 +92,7 @@ tests:
   spec:
     main: Spec.hs
     source-dirs: test
-    ghc-options: -Wall "-with-rtsopts=-K1K"
+    ghc-options: "-with-rtsopts=-K1K"
     cpp-options: -DTEST
     dependencies:
     - hspec >=1.3

--- a/yaml/yaml.cabal
+++ b/yaml/yaml.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 55c85c8d4d3074a558a82e30a2592ecff9db2e6f1571547c73d26ba44bfc1c20
 
 name:           yaml
 version:        0.11.5.0
@@ -62,8 +60,9 @@ library
       Paths_yaml
   hs-source-dirs:
       src
-  other-extensions: LambdaCase
-  ghc-options: -Wall
+  other-extensions:
+      LambdaCase
+  ghc-options: -Wall -Wcompat
   build-depends:
       aeson >=0.11
     , attoparsec >=0.11.3.0
@@ -73,7 +72,7 @@ library
     , containers
     , directory
     , filepath
-    , libyaml >=0.1 && <0.2
+    , libyaml ==0.1.*
     , mtl
     , resourcet >=0.3 && <1.3
     , scientific >=0.3
@@ -82,9 +81,6 @@ library
     , transformers >=0.1
     , unordered-containers
     , vector
-  if !impl(ghc >= 8.0)
-    build-depends:
-        semigroups
   default-language: Haskell2010
 
 executable examples
@@ -95,7 +91,7 @@ executable examples
       Paths_yaml
   hs-source-dirs:
       examples
-  ghc-options: -Wall
+  ghc-options: -Wall -Wcompat
   build-depends:
       aeson >=0.11
     , attoparsec >=0.11.3.0
@@ -105,7 +101,7 @@ executable examples
     , containers
     , directory
     , filepath
-    , libyaml >=0.1 && <0.2
+    , libyaml ==0.1.*
     , mtl
     , resourcet >=0.3 && <1.3
     , scientific >=0.3
@@ -114,9 +110,6 @@ executable examples
     , transformers >=0.1
     , unordered-containers
     , vector
-  if !impl(ghc >= 8.0)
-    build-depends:
-        semigroups
   if flag(no-examples)
     buildable: False
   else
@@ -131,6 +124,7 @@ executable json2yaml
       Paths_yaml
   hs-source-dirs:
       exe
+  ghc-options: -Wall -Wcompat
   build-depends:
       aeson >=0.11
     , attoparsec >=0.11.3.0
@@ -140,7 +134,7 @@ executable json2yaml
     , containers
     , directory
     , filepath
-    , libyaml >=0.1 && <0.2
+    , libyaml ==0.1.*
     , mtl
     , resourcet >=0.3 && <1.3
     , scientific >=0.3
@@ -150,9 +144,6 @@ executable json2yaml
     , unordered-containers
     , vector
     , yaml
-  if !impl(ghc >= 8.0)
-    build-depends:
-        semigroups
   if flag(no-exe)
     buildable: False
   default-language: Haskell2010
@@ -163,6 +154,7 @@ executable yaml2json
       Paths_yaml
   hs-source-dirs:
       exe
+  ghc-options: -Wall -Wcompat
   build-depends:
       aeson >=0.11
     , attoparsec >=0.11.3.0
@@ -172,7 +164,7 @@ executable yaml2json
     , containers
     , directory
     , filepath
-    , libyaml >=0.1 && <0.2
+    , libyaml ==0.1.*
     , mtl
     , resourcet >=0.3 && <1.3
     , scientific >=0.3
@@ -182,9 +174,6 @@ executable yaml2json
     , unordered-containers
     , vector
     , yaml
-  if !impl(ghc >= 8.0)
-    build-depends:
-        semigroups
   if flag(no-exe)
     buildable: False
   default-language: Haskell2010
@@ -199,7 +188,7 @@ test-suite spec
       Paths_yaml
   hs-source-dirs:
       test
-  ghc-options: -Wall "-with-rtsopts=-K1K"
+  ghc-options: -Wall -Wcompat -with-rtsopts=-K1K
   cpp-options: -DTEST
   build-depends:
       HUnit
@@ -213,7 +202,7 @@ test-suite spec
     , directory
     , filepath
     , hspec >=1.3
-    , libyaml >=0.1 && <0.2
+    , libyaml ==0.1.*
     , mockery
     , mtl
     , raw-strings-qq
@@ -226,7 +215,4 @@ test-suite spec
     , unordered-containers
     , vector
     , yaml
-  if !impl(ghc >= 8.0)
-    build-depends:
-        semigroups
   default-language: Haskell2010

--- a/yaml/yaml.cabal
+++ b/yaml/yaml.cabal
@@ -154,6 +154,10 @@ executable yaml2json
       Paths_yaml
   hs-source-dirs:
       exe
+  other-extensions:
+      CPP
+      LambdaCase
+      NamedFieldPuns
   ghc-options: -Wall -Wcompat
   build-depends:
       aeson >=0.11
@@ -166,6 +170,7 @@ executable yaml2json
     , filepath
     , libyaml ==0.1.*
     , mtl
+    , optparse-applicative
     , resourcet >=0.3 && <1.3
     , scientific >=0.3
     , template-haskell


### PR DESCRIPTION
Fix #195: options --help and --version

Preparatory patch: Since we have GHC>=8 (base >=4.9), we can simplify package.yaml

- remove conditional semigroups dependency
- add -Wall and -Wcompat (GHC 8) to all goals

## yaml2json

Using optparse-applicative, let yaml2json understand options

    --help | -h
    --version | -V | --numeric-version

in a robust way.

Otherwise, no change of cmdline syntax:

    yaml2json file.yml     # read from file
    yaml2json -            # read from stdin

Tested build with GHC 8.0 - 9.0.

## json2yaml

NYI, if everything is fine with the `yaml2json` half, I implement it for `json2yaml` likewise.