### PR TITLE
Re #195: json2yaml now uses optparse-applicative

### DIFF
--- a/yaml/README.md
+++ b/yaml/README.md
@@ -16,3 +16,11 @@ Usage examples can be found in the `Data.Yaml` documentation or in the [examples
 * `Data.Yaml.Include` supports adding `!include` directives to your YAML files.
 * `Data.Yaml.Builder` and `Data.Yaml.Parser` allow more fine-grained control of parsing an rendering, as opposed to just using the aeson typeclass and datatype system for parsing and rendering.
 * `Data.Yaml.Aeson` is currently a re-export of `Data.Yaml` to explicitly choose to use the aeson-compatible API.
+
+### Executables
+
+Converters `json2yaml` and `yaml2json` can be built by disabling flag `no-exe`, e.g., one of:
+```
+cabal install yaml -f-no-exe
+stack install yaml --flag yaml:-no-exe
+```

--- a/yaml/exe/Common.hs
+++ b/yaml/exe/Common.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- | Code shared between @yaml2json@ and @json2yaml@.
+
+module Common where
+
+import Data.List            ( intercalate )
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup       ( Semigroup(..) )
+#endif
+import Data.Version         ( Version(versionBranch) )
+
+import Options.Applicative  ( Parser, help, hidden, infoOption, long, short )
+
+import qualified Paths_yaml as Paths
+
+-- * Version info and option
+---------------------------------------------------------------------------
+
+-- | Homepage for @yaml2json@ and @json2yaml@.
+
+homepage :: String
+homepage = "https://github.com/snoyberg/yaml/"
+
+-- | Version in @x.y.z@ format.
+
+version :: String
+version = intercalate "." $ map show $ versionBranch Paths.version
+
+-- | Option @--numeric-version@.
+
+numericVersionOption :: Parser (a -> a)
+numericVersionOption =
+  infoOption version
+    $  long "numeric-version"
+    <> hidden
+    <> help "Show just version number."
+
+-- | Option @--version@.
+
+versionOption :: String -> Parser (a -> a)
+versionOption self =
+  infoOption (unwords versionWords)
+    $  long "version"
+    <> short 'V'
+    <> hidden
+    <> help "Show version info."
+  where
+  versionWords = [ self, "version", version, homepage ]
+
+-- * Misc
+---------------------------------------------------------------------------
+
+-- | @Just@ unless argument is @"-"@ (denoting @stdin@ or @stdout@).
+
+dashToNothing :: FilePath -> Maybe FilePath
+dashToNothing = \case
+  "-"  -> Nothing
+  file -> Just file

--- a/yaml/exe/yaml2json.hs
+++ b/yaml/exe/yaml2json.hs
@@ -7,27 +7,26 @@ import Prelude hiding (putStr, getContents)
 import Data.Aeson           (encode, Value)
 import Data.ByteString      (getContents)
 import Data.ByteString.Lazy (putStr)
-import Data.List            (intercalate)
 #if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup       (Semigroup(..))
 #endif
-import Data.Version         (Version(versionBranch))
 import Data.Yaml            (decodeFileEither, decodeEither')
 
 import Options.Applicative
   ( Parser
-  , action, execParser, header, help, helper, hidden
-  , info, infoOption, long, metavar, short, strArgument
+  , action, execParser, header, help, helper, info
+  , metavar, strArgument
   )
 
 import System.Exit
 import System.IO (stderr, hPrint)
 
-import qualified Paths_yaml as Paths
+import Common
+  ( versionOption, numericVersionOption, dashToNothing )
 
 newtype Options = Options
   { optInput :: Maybe FilePath
-      -- ^ Nothing means @stdin@.
+      -- ^ 'Nothing' means @stdin@.
   }
 
 -- | Name of the executable.
@@ -35,52 +34,23 @@ newtype Options = Options
 self :: String
 self = "yaml2json"
 
--- | Homepage for this program.
-
-homepage :: String
-homepage = "https://github.com/snoyberg/yaml/"
-
--- | Version in @x.y.z@ format.
-
-version :: String
-version = intercalate "." $ map show $ versionBranch Paths.version
-
 -- | Parse options; handle parse errors, @--help@, @--version@.
 
 options :: IO Options
 options =
   execParser $
-    info (helper <*> versionOption <*> numericVersionOption <*> programOptions)
-         (header "Reads given YAML document and prints it JSON format to standard out.")
+    info (helper <*> versionOption self <*> numericVersionOption <*> programOptions)
+         (header "Reads given YAML document and prints it in JSON format to standard out.")
 
   where
-  versionOption =
-    infoOption (unwords versionWords)
-      $  long "version"
-      <> short 'V'
-      <> hidden
-      <> help "Show version info."
-  versionWords = [ self, "version", version, homepage ]
-
-  numericVersionOption =
-    infoOption version
-      $  long "numeric-version"
-      <> hidden
-      <> help "Show just version number."
-
   programOptions = Options <$> oInput
 
   oInput :: Parser (Maybe FilePath)
-  oInput = dashToStdin <$> do
+  oInput = dashToNothing <$> do
     strArgument
       $  metavar "FILE"
       <> action "file"
       <> help "The input file containing the YAML document; use '-' for stdin."
-    where
-    -- dash is interpreted as stdin
-    dashToStdin = \case
-          "-"  -> Nothing
-          file -> Just file
 
 showJSON :: Show a => Either a Value -> IO b
 showJSON = \case

--- a/yaml/package.yaml
+++ b/yaml/package.yaml
@@ -64,6 +64,7 @@ executables:
     main: json2yaml.hs
     source-dirs: exe
     dependencies:
+    - optparse-applicative
     - yaml
     when:
     - condition: flag(no-exe)

--- a/yaml/yaml.cabal
+++ b/yaml/yaml.cabal
@@ -121,6 +121,7 @@ executable examples
 executable json2yaml
   main-is: json2yaml.hs
   other-modules:
+      Common
       Paths_yaml
   hs-source-dirs:
       exe
@@ -136,6 +137,7 @@ executable json2yaml
     , filepath
     , libyaml ==0.1.*
     , mtl
+    , optparse-applicative
     , resourcet >=0.3 && <1.3
     , scientific >=0.3
     , template-haskell

--- a/yaml/yaml.cabal
+++ b/yaml/yaml.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           yaml
-version:        0.11.5.0
+version:        0.11.6.0
 synopsis:       Support for parsing and rendering YAML documents.
 description:    README and API documentation are available at <https://www.stackage.org/package/yaml>
 category:       Data
@@ -151,6 +151,7 @@ executable json2yaml
 executable yaml2json
   main-is: yaml2json.hs
   other-modules:
+      Common
       Paths_yaml
   hs-source-dirs:
       exe


### PR DESCRIPTION
Re #195: `json2yaml` now uses `optparse-applicative`

The help text now looks like this:

    Reads a JSON document and writes it out as YAML document.

    Usage: json2yaml [IN] [OUT]

    Available options:
      -h,--help                Show this help text
      -V,--version             Show version info.
      --numeric-version        Show just version number.
      IN                       The input file containing the JSON document; use '-'
                               for stdin.
      OUT                      The file to hold the produced YAML document; use '-'
                               for stdout.

Only semantic change: use `die` instead of `error`, so the error

    json2yaml: Invalid input JSON
    CallStack (from HasCallStack):
      error, called at exe/json2yaml.hs:19:20 in main:Main

is now just

    json2yaml: Invalid input JSON

Also: mention `json2yaml` and friend in the README.