### PR TITLE
Fix #199: adding option -o to the converters

### DIFF
--- a/yaml/exe/Common.hs
+++ b/yaml/exe/Common.hs
@@ -28,6 +28,16 @@ homepage = "https://github.com/snoyberg/yaml/"
 version :: String
 version = intercalate "." $ map show $ versionBranch Paths.version
 
+-- | The version header including given program name and 'homepage'.
+
+versionText :: String -> String
+versionText self = unwords
+  [ self
+  , "version"
+  , version
+  , homepage  -- concat [ "<", homepage, ">" ]
+  ]
+
 -- | Option @--numeric-version@.
 
 numericVersionOption :: Parser (a -> a)
@@ -41,13 +51,11 @@ numericVersionOption =
 
 versionOption :: String -> Parser (a -> a)
 versionOption self =
-  infoOption (unwords versionWords)
+  infoOption (versionText self)
     $  long "version"
     <> short 'V'
     <> hidden
     <> help "Show version info."
-  where
-  versionWords = [ self, "version", version, homepage ]
 
 -- * Misc
 ---------------------------------------------------------------------------

--- a/yaml/exe/json2yaml.hs
+++ b/yaml/exe/json2yaml.hs
@@ -45,8 +45,7 @@ options =
   where
   hdoc = Just $ vcat $ map text
     [ versionText self
-    , ""
-    , "Reads a JSON document and writes it out as YAML document."
+    , "Convert JSON to YAML."
     ]
   fdoc = Just $ text $ concat
     [ "The old call pattern '"

--- a/yaml/exe/json2yaml.hs
+++ b/yaml/exe/json2yaml.hs
@@ -10,14 +10,16 @@ import Data.Semigroup ( Semigroup(..) )
 #endif
 
 import Options.Applicative
-  ( Parser
-  , action, execParser, header, help, helper, info
-  , metavar, strArgument, value
+  ( Parser, (<|>)
+  , action, execParser, footerDoc, headerDoc, help, helper, hidden, info
+  , long, metavar, short, strArgument, strOption, value
   )
+import Options.Applicative.Help.Pretty
+  ( vcat, text )
 
 import System.Exit    ( die )
 
-import Common         ( dashToNothing, versionOption, numericVersionOption )
+import Common         ( dashToNothing, versionText, versionOption, numericVersionOption )
 
 data Options = Options
   { optInput  :: Maybe FilePath
@@ -37,9 +39,22 @@ options :: IO Options
 options =
   execParser $
     info (helper <*> versionOption self <*> numericVersionOption <*> programOptions)
-         (header "Reads a JSON document and writes it out as YAML document.")
+      $  headerDoc hdoc
+      <> footerDoc fdoc
 
   where
+  hdoc = Just $ vcat $ map text
+    [ versionText self
+    , ""
+    , "Reads a JSON document and writes it out as YAML document."
+    ]
+  fdoc = Just $ text $ concat
+    [ "The old call pattern '"
+    , self
+    , " IN OUT' is also accepted, but deprecated."
+    ]
+
+  programOptions :: Parser Options
   programOptions = Options <$> oInput <*> oOutput
 
   oInput :: Parser (Maybe FilePath)
@@ -48,15 +63,29 @@ options =
       $  metavar "IN"
       <> value "-"
       <> action "file"
-      <> help "The input file containing the JSON document; use '-' for stdin."
+      <> help "The input file containing the JSON document; use '-' for stdin (default)."
 
   oOutput :: Parser (Maybe FilePath)
   oOutput = dashToNothing <$> do
+    oOutputExplicit <|> oOutputImplicit
+
+  oOutputExplicit :: Parser FilePath
+  oOutputExplicit =
+    strOption
+      $  long "output"
+      <> short 'o'
+      <> metavar "OUT"
+      <> action "file"
+      -- <> help "The file to hold the produced YAML document; use '-' for stdout (default)."
+
+  oOutputImplicit :: Parser FilePath
+  oOutputImplicit =
     strArgument
       $  metavar "OUT"
       <> value "-"
       <> action "file"
-      <> help "The file to hold the produced YAML document; use '-' for stdout."
+      <> hidden
+      <> help "The file to hold the produced YAML document; use '-' for stdout (default)."
 
 -- | Exit with 'self'-stamped error message.
 


### PR DESCRIPTION
With added option `-o`, the interfaces look like this:

`$ yaml2json -h`

    yaml2json version 0.11.6.0 https://github.com/snoyberg/yaml/
    Convert YAML to JSON.

    Usage: yaml2json [IN] [-o|--output OUT]

    Available options:
      -h,--help                Show this help text
      -V,--version             Show version info.
      --numeric-version        Show just version number.
      IN                       The input file containing the YAML document; use '-'
                               for stdin (default).
      -o,--output OUT          The file to hold the produced JSON document; use '-'
                               for stdout (default).

`$ json2yaml -h`

    json2yaml version 0.11.6.0 https://github.com/snoyberg/yaml/
    Convert JSON to YAML.

    Usage: json2yaml [IN] [-o|--output OUT]

    Available options:
      -h,--help                Show this help text
      -V,--version             Show version info.
      --numeric-version        Show just version number.
      IN                       The input file containing the JSON document; use '-'
                               for stdin (default).
      OUT                      The file to hold the produced YAML document; use '-'
                               for stdout (default).

    The old call pattern 'json2yaml IN OUT' is also accepted, but deprecated.
