### PR TITLE
Export Parse and Stringstyle

### DIFF
--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -16,7 +16,7 @@ module Data.Yaml.Internal
     , decodeAllHelper_
     , textToScientific
     , stringScalar
-    , Stringstyle
+    , StringStyle
     , defaultStringStyle
     , isSpecialString
     , specialStrings

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -9,12 +9,14 @@ module Data.Yaml.Internal
     , prettyPrintParseException
     , Warning(..)
     , parse
+    , Parse
     , decodeHelper
     , decodeHelper_
     , decodeAllHelper
     , decodeAllHelper_
     , textToScientific
     , stringScalar
+    , Stringstyle
     , defaultStringStyle
     , isSpecialString
     , specialStrings


### PR DESCRIPTION
Uses of decodeHelper or defaultStringStyle aren't able to give type signatures
to their own functions when these are not available. Stringstyle is a synonym one
could recreate as a workaround, but that does not work for Parse.

**NOTE**: I had a small typo, so I recommend Squash-merge.