### PR TITLE
Streaming parser

### DIFF
--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -247,7 +247,7 @@ parseSubStream = do
     me <- lift CL.head
     case me of
       Just (EventSequenceStart _ _ a) -> parseArrayStreaming 0 a
-      _ -> liftIO $ throwIO $ UnexpectedEvent me Nothing
+      _ -> liftIO $ throwIO $ UnexpectedEvent me $ Just $ EventSequenceStart NoTag AnySequence Nothing
 
 parseArrayStreaming :: Int -> Y.Anchor -> ReaderT JSONPath (ConduitM Event Value Parse) ()
 parseArrayStreaming !n a = do

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -256,7 +256,7 @@ parseArrayStreaming !n a = do
         Just EventSequenceEnd -> lift $ CL.drop 1
         _ -> do
             local (Index n :) parseO >>= lift . yield
-            parseArrayStreaming (succ n) a
+            parseArrayStreaming (n+1) a
 
 parseScalar :: ByteString -> Anchor -> Style -> Tag
             -> ReaderT JSONPath (ConduitM Event o Parse) Text

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -218,7 +218,11 @@ parseAll = do
             _ -> missed documentStart
     missed event = liftIO $ throwIO $ UnexpectedEvent event Nothing
 
--- | Parse a stream of values.
+-- | Parse a yaml file (as a stream of events) to a stream of values.
+--   It only accepts documents whose top-level entity is an array.
+--
+--   In combination with 'Y.decodeFile', it can be used to consume
+--   a yaml file that consists in a very large list of values.
 parseStream :: ReaderT JSONPath (ConduitM Event Value Parse) ()
 parseStream = do
     streamStart <- lift CL.head

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -11,6 +11,7 @@ module Data.Yaml.Internal
     , parse
     , parseStream
     , Parse
+    , ParseState (..)
     , decodeHelper
     , decodeHelper_
     , decodeAllHelper

--- a/yaml/yaml.cabal
+++ b/yaml/yaml.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           yaml
-version:        0.11.7.0
+version:        0.11.8.0
 synopsis:       Support for parsing and rendering YAML documents.
 description:    README and API documentation are available at <https://www.stackage.org/package/yaml>
 category:       Data


### PR DESCRIPTION
I added the ability to consume yaml files incrementally using conduits. This is exposed by the `parseStream` function in the module `Data.Yaml.Internal`.

The motivation was simply wanting to consume large files without having to have them fully in memory. I don't know what the demand for something like this is, but I wanted it.

I was thinking maybe to define a wrapper in `Data.Yaml` that would be easier to use and discover. However, I wasn't sure what that would look like. In any case, exporting the conduit works well enough for myself.

I also had to export `ParseState` or otherwise I wasn't able to run the parser.

To try it out, I wrote the following code:

```haskell
{-# LANGUAGE ImportQualifiedPost, OverloadedStrings #-}

module Main (main) where

import Data.Void (Void)
import Data.Aeson (FromJSON, parseJSON, withObject, (.:), fromJSON)
import Data.Aeson qualified as JSON
import Conduit (ConduitM, runConduit, (.|), runResourceT)
import Data.Conduit.List qualified as CL
import Data.Yaml.Internal (Parse, ParseState (..), parseStream)
import Control.Monad.Reader (runReaderT)
import Control.Monad.State.Strict (evalStateT)
import Text.Libyaml (decodeFile)

data ID = ID { id_field :: Int }

instance FromJSON ID where
  parseJSON = withObject "ID" $ \o -> fmap ID $ o .: "id"

main :: IO ()
main = do
  let f :: Int -> JSON.Value -> Int
      f i v =
        case fromJSON v of
          JSON.Error err -> error err
          JSON.Success x -> i + id_field x
  let conduit :: ConduitM () Void Parse Int
      conduit = decodeFile "big.yaml"
             .| runReaderT parseStream []
             .| CL.fold f 0
  r <- runResourceT $ evalStateT (runConduit conduit) $ ParseState mempty []
  print r
```

And then I created a 1,5Gb file (`big.yaml`). The memory still goes up as the program runs, but does so very slowly and the program finishes before it is a problem (it ends up taking close to 3Gb though). Trying to parse the entire file quickly used all of my available memory (31,2Gb). I was expecting the conduit version to take a roughly constant amount of memory. I wonder what causes the slow build up. Could it be related to the parser state?

Thanks in advance for your review.