### PR TITLE
Use qualified import on Data.List

### DIFF
--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -51,7 +51,7 @@ import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BL
 import Data.ByteString.Builder.Scientific (scientificBuilder)
 import Data.Char (toUpper, ord)
-import Data.List
+import qualified Data.List as List
 import Data.Conduit ((.|), ConduitM, runConduit)
 import qualified Data.Conduit.List as CL
 import qualified Data.HashSet as HashSet
@@ -314,14 +314,14 @@ parseM mergedKeys a front = do
               if s == "<<"
                          then case o of
                                   Object l  -> return (merge l)
-                                  Array l -> return $ merge $ foldl' mergeObjects M.empty $ V.toList l
+                                  Array l -> return $ merge $ List.foldl' mergeObjects M.empty $ V.toList l
                                   _          -> al
                          else al
             parseM mergedKeys' a al'
     where mergeObjects al (Object om) = M.union al om
           mergeObjects al _           = al
 
-          merge xs = (Set.fromList (M.keys xs \\ M.keys front), M.union front xs)
+          merge xs = (Set.fromList (M.keys xs List.\\ M.keys front), M.union front xs)
 
 parseSrc :: ReaderT JSONPath (ConduitM Event Void Parse) val
          -> ConduitM () Event Parse ()


### PR DESCRIPTION
Following this issue: https://github.com/haskell/core-libraries-committee/issues/22
- in the future Data.List will be monomorphized, and as such it is suggested by this compat warning:
```
src/Data/Yaml/Internal.hs:54:8: warning: [-Wcompat-unqualified-imports]
    To ensure compatibility with future core libraries changes
    imports to Data.List should be
    either qualified or have an explicit import list.
   |
54 | import Data.List
```
This PR thus makes this import qualified.