### PR TITLE
fix: Ambiguous occurrence AesonException

### DIFF
--- a/yaml/ChangeLog.md
+++ b/yaml/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yaml
 
+## 0.11.11.0
+
+* Fix ambiguous occurrence `AesonException`
+
 ## 0.11.10.0
 
 * Undo previous change (breakage with aeson 2)

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -34,10 +34,10 @@ import Control.Monad (when, unless)
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import Control.Monad.State.Strict
 import Control.Monad.Reader
-#if MIN_VERSION_aeson(2,1,2)
-import Data.Aeson hiding (AesonException)
-#else
+#if MIN_VERSION_aeson(2,1,1)
 import Data.Aeson
+#else
+import Data.Aeson hiding (AesonException)
 #endif
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key as K

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -34,7 +34,11 @@ import Control.Monad (when, unless)
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import Control.Monad.State.Strict
 import Control.Monad.Reader
+#if MIN_VERSION_aeson(2,1,2)
+import Data.Aeson hiding (AesonException)
+#else
 import Data.Aeson
+#endif
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key as K
 import qualified Data.Aeson.KeyMap as M

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -34,10 +34,10 @@ import Control.Monad (when, unless)
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import Control.Monad.State.Strict
 import Control.Monad.Reader
-#if MIN_VERSION_aeson(2,1,1)
-import Data.Aeson
-#else
+#if MIN_VERSION_aeson(2,1,2)
 import Data.Aeson hiding (AesonException)
+#else
+import Data.Aeson
 #endif
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key as K


### PR DESCRIPTION
As @andrewthad mentioned, a new `AesonException` type was introduced in `aeson-2.1.2.0` causing conflicts with the `AesonException` constructor defined inside [Data.Yaml.Internal](https://github.com/snoyberg/yaml/blob/master/yaml/src/Data/Yaml/Internal.hs) module

<img width="433" alt="image" src="https://user-images.githubusercontent.com/2049686/221048846-b8e97a53-6137-4e8a-b808-3e1ceb5ca2ce.png">

Source: https://hackage.haskell.org/package/aeson-2.1.2.0/docs/Data-Aeson.html#t:AesonException

Closes #211 