### PR TITLE
For `optparse-applicative-0.18`: use `pretty` instead of `text`

### DIFF
--- a/yaml/exe/json2yaml.hs
+++ b/yaml/exe/json2yaml.hs
@@ -15,7 +15,7 @@ import Options.Applicative
   , long, metavar, short, strArgument, strOption, value
   )
 import Options.Applicative.Help.Pretty
-  ( vcat, text )
+  ( vcat, pretty )
 
 import System.Exit    ( die )
 
@@ -43,11 +43,11 @@ options =
       <> footerDoc fdoc
 
   where
-  hdoc = Just $ vcat $ map text
+  hdoc = Just $ vcat $ map pretty
     [ versionText self
     , "Convert JSON to YAML."
     ]
-  fdoc = Just $ text $ concat
+  fdoc = Just $ pretty $ concat
     [ "The old call pattern '"
     , self
     , " IN OUT' is also accepted, but deprecated."

--- a/yaml/exe/yaml2json.hs
+++ b/yaml/exe/yaml2json.hs
@@ -17,7 +17,7 @@ import Options.Applicative
   , long, metavar, short, strArgument, strOption, value
   )
 import Options.Applicative.Help.Pretty
-  ( vcat, text )
+  ( vcat, pretty )
 
 import Common
   ( versionText, versionOption, numericVersionOption, dashToNothing )
@@ -43,7 +43,7 @@ options =
          (headerDoc hdoc)
 
   where
-  hdoc = Just $ vcat $ map text
+  hdoc = Just $ vcat $ map pretty
     [ versionText self
     , "Convert YAML to JSON."
     ]


### PR DESCRIPTION
Fixes #215
