### PR TITLE
Allow compilation with aeson 2.2.0.0.

### DIFF
--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -50,7 +50,7 @@ import qualified Data.HashMap.Strict as M
 import Data.Aeson.Types hiding (AesonException, parse)
 #else
 import Data.Aeson.Types hiding (parse)
-import Data.Aeson.Internal (formatError)
+import Data.Aeson.Internal (JSONPath, JSONPathElement(..), formatError)
 #endif
 import qualified Data.Attoparsec.Text as Atto
 import Data.Bits (shiftL, (.|.))

--- a/yaml/src/Data/Yaml/Internal.hs
+++ b/yaml/src/Data/Yaml/Internal.hs
@@ -46,8 +46,12 @@ import Data.Aeson.KeyMap (KeyMap)
 #else
 import qualified Data.HashMap.Strict as M
 #endif
-import Data.Aeson.Internal (JSONPath, JSONPathElement(..), formatError)
+#if MIN_VERSION_aeson(2,2,0)
+import Data.Aeson.Types hiding (AesonException, parse)
+#else
 import Data.Aeson.Types hiding (parse)
+import Data.Aeson.Internal (formatError)
+#endif
 import qualified Data.Attoparsec.Text as Atto
 import Data.Bits (shiftL, (.|.))
 import Data.ByteString (ByteString)

--- a/yaml/test/Data/Yaml/IncludeSpec.hs
+++ b/yaml/test/Data/Yaml/IncludeSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Data.Yaml.IncludeSpec (main, spec) where
@@ -6,7 +7,11 @@ import           Test.Hspec
 import           Data.List (isPrefixOf)
 import qualified Data.ByteString.Lazy as LB
 import           Data.Aeson
+#if MIN_VERSION_aeson(2,2,0)
 import           Data.Aeson.Types (JSONPathElement(..))
+#else
+import           Data.Aeson.Internal (JSONPathElement(..))
+#endif
 import           Data.Yaml (ParseException(InvalidYaml))
 import           Data.Yaml.Include
 import           Data.Yaml.Internal

--- a/yaml/test/Data/Yaml/IncludeSpec.hs
+++ b/yaml/test/Data/Yaml/IncludeSpec.hs
@@ -6,7 +6,7 @@ import           Test.Hspec
 import           Data.List (isPrefixOf)
 import qualified Data.ByteString.Lazy as LB
 import           Data.Aeson
-import           Data.Aeson.Internal (JSONPathElement(..))
+import           Data.Aeson.Types (JSONPathElement(..))
 import           Data.Yaml (ParseException(InvalidYaml))
 import           Data.Yaml.Include
 import           Data.Yaml.Internal


### PR DESCRIPTION
This version of aeson removes Data.Aeson.Internal, but exports the things yaml needed from it in Data.Aeson.Types.

CPP has been used to make it work with both 2.2 and earlier versions. However, I was only able to test with aeson 2.1; attempts to constrain the build to earlier versions did not produce a viable build path.

Closes #219.