### PR TITLE
Allow ByteString that is the result of serialization to be freed

### DIFF
--- a/libyaml/src/Text/Libyaml.hs
+++ b/libyaml/src/Text/Libyaml.hs
@@ -776,7 +776,7 @@ encodeWith opts =
     close _ fbuf = withForeignPtr fbuf $ \b -> do
         ptr' <- c_get_buffer_buff b
         len <- c_get_buffer_used b
-        fptr <- newForeignPtr_ $ castPtr ptr'
+        fptr <- newForeignPtr finalizerFree $ castPtr ptr'
         return $ B.fromForeignPtr fptr 0 $ fromIntegral len
 
 


### PR DESCRIPTION
Fixes #232